### PR TITLE
remove pypy3 miniforge & bump version to 24.7.1-2

### DIFF
--- a/.github/workflows/fuzzy_compile_weekly.yml
+++ b/.github/workflows/fuzzy_compile_weekly.yml
@@ -71,8 +71,8 @@ jobs:
         if: runner.os != 'Windows'
         uses: conda-incubator/setup-miniconda@v3.0.1
         with:
-          miniforge-variant: Miniforge-pypy3
-          miniforge-version: 24.7.1-0
+          miniforge-variant: Miniforge3
+          miniforge-version: 24.7.1-2
           environment-file: sophios/install/system_deps.yml
           activate-environment: wic
           channels: conda-forge

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -137,8 +137,8 @@ jobs:
         if: runner.os != 'Windows'
         uses: conda-incubator/setup-miniconda@v3.0.1
         with:
-          miniforge-variant: Miniforge-pypy3
-          miniforge-version: 24.7.1-0
+          miniforge-variant: Miniforge3
+          miniforge-version: 24.7.1-2
           environment-file: sophios/install/system_deps.yml
           activate-environment: wic
           channels: conda-forge
@@ -148,8 +148,8 @@ jobs:
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v3.0.1
         with:
-          miniforge-variant: Miniforge-pypy3
-          miniforge-version: 24.7.1-0
+          miniforge-variant: Miniforge3
+          miniforge-version: 24.7.1-2
           environment-file: sophios/install/system_deps_windows.yml
           activate-environment: wic
           channels: conda-forge

--- a/.github/workflows/lint_and_test_macos.yml
+++ b/.github/workflows/lint_and_test_macos.yml
@@ -71,8 +71,8 @@ jobs:
         if: runner.os != 'Windows'
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniforge-variant: Miniforge-pypy3
-          miniforge-version: 24.7.1-0
+          miniforge-variant: Miniforge3
+          miniforge-version: 24.7.1-2
           environment-file: sophios/install/system_deps.yml
           activate-environment: wic
           use-mamba: true

--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -126,8 +126,8 @@ jobs:
       if: always()
       uses: conda-incubator/setup-miniconda@v3.0.1
       with:
-        miniforge-variant: Miniforge-pypy3
-        miniforge-version: 24.7.1-0
+        miniforge-variant: Miniforge3
+        miniforge-version: 24.7.1-2
         environment-file: sophios/install/system_deps.yml
         activate-environment: wic_github_actions
         channels: conda-forge

--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -84,12 +84,12 @@ jobs:
       if: always()
       uses: conda-incubator/setup-miniconda@v3.0.1
       with:
-        miniforge-variant: Miniforge  # NOT Miniforge-pypy3
+        miniforge-variant: Miniforge3  # NOT Miniforge-pypy3
         # Toil is (currently) incompatible with pypy. Miniforge-pypy3
         # installs pypy in the base environment (only). Although we are using
         # another environment, better to avoid the problem altogether by
         # not using Miniforge-pypy3
-        miniforge-version: 24.7.1-0
+        miniforge-version: 24.7.1-2
         environment-file: sophios/install/system_deps.yml
         activate-environment: wic_github_actions
         use-mamba: true


### PR DESCRIPTION
This removes miniforge-pypy3 from all Ci workflows. It also fixes runworkflows_weekly miniforge error due to incorrect name of the miniforge channel.