### PR TITLE
Don't copy output to outdir if not using cwltool

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,7 +1,7 @@
 name: Build and Test Wheel
 
 on:
-  pull_request: 
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
           python -m build --sdist
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: sophios-wheels
             path: dist/*

--- a/src/sophios/api/pythonapi.py
+++ b/src/sophios/api/pythonapi.py
@@ -797,7 +797,7 @@ class Workflow(BaseModel):
 
         # Finally, since there is an output file copying bug in cwltool,
         # we need to copy the output files manually. See comment above.
-        if args.copy_output_files:
+        if args.cwl_runner == 'cwltool' and args.copy_output_files:
             run_local_module.copy_output_files(self.process_name)
 
 # Process = Union[Step, Workflow]

--- a/src/sophios/main.py
+++ b/src/sophios/main.py
@@ -203,7 +203,7 @@ def main() -> None:
 
         # Finally, since there is an output file copying bug in cwltool,
         # we need to copy the output files manually. See comment above.
-        if args.copy_output_files:
+        if args.cwl_runner == 'cwltool' and args.copy_output_files:
             run_local.copy_output_files(yaml_stem)
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -230,7 +230,7 @@ def run_workflows(yml_path_str: str, yml_path: Path, cwl_runner: str, args: argp
 
     # Finally, since there is an output file copying bug in cwltool,
     # we need to copy the output files manually. See comment above.
-    if args.copy_output_files:
+    if args.cwl_runner == 'cwltool' and args.copy_output_files:
         sophios.run_local.copy_output_files(yaml_stem)
 
 


### PR DESCRIPTION
this is fixes the problem of long wait times to copy files when using toil.