### PR TITLE
append name of workflow to default outdir_toil

### DIFF
--- a/src/sophios/run_local.py
+++ b/src/sophios/run_local.py
@@ -10,6 +10,7 @@ import shutil
 import platform
 import traceback
 from typing import Dict, List, Optional
+from datetime import datetime
 
 try:
     import cwltool.main
@@ -245,7 +246,9 @@ def run_local(args: argparse.Namespace, rose_tree: RoseTree, cachedir: Optional[
         # https://github.com/DataBiosphere/toil/blob/6558c7f97fb37c6ef6f469c7ae614109050322f4/src/toil/options/cwl.py#L152
         docker_pull = []  # toil supports --force-docker-pull, but not --disable-pull
         cmd = ['toil-cwl-runner'] + docker_pull + net + provenance + docker_cmd_ + path_check
-        cmd += ['--outdir', 'outdir_toil',
+        now = datetime.now()
+        date_time = now.strftime("%Y%m%d%H%M%S")
+        cmd += ['--outdir', f'outdir_toil_{yaml_stem}_{date_time}',
                 '--jobStore', f'file:./jobStore_{yaml_stem}',  # NOTE: This is the equivalent of --cachedir
                 # TODO: Check --clean, --cleanWorkDir, --restart
                 '--clean', 'always',  # This effectively disables caching, but is reproducible


### PR DESCRIPTION
fixes overwriting of outputs from multiple workflows into the same default outdir_toil.