### PR TITLE
fix upload-artifcat to v4

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,7 +1,7 @@
 name: Build and Test Wheel
 
 on:
-  pull_request: 
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
           python -m build --sdist
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: sophios-wheels
             path: dist/*


### PR DESCRIPTION
Move from deprecated v3 to v4 of upload artifacts.

[Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)