### PR TITLE
fix : Modernize GitHub Actions workflows

### DIFF
--- a/.github/my_actions/branch_dispatch/action.yml
+++ b/.github/my_actions/branch_dispatch/action.yml
@@ -62,5 +62,5 @@ outputs:
   response:
     description: 'The response text'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/my_actions/check_existence/action.yml
+++ b/.github/my_actions/check_existence/action.yml
@@ -34,5 +34,5 @@ outputs:
   ref:
     description: 'The name of the branch / ref'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/my_actions/check_membership/action.yml
+++ b/.github/my_actions/check_membership/action.yml
@@ -14,5 +14,5 @@ outputs:
   verified:
     description: 'Whether the account is a verified member or trusted account'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/my_actions/reply_sender/action.yml
+++ b/.github/my_actions/reply_sender/action.yml
@@ -38,5 +38,5 @@ outputs:
   response:
     description: 'The response text'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/workflows/branch_dispatch_pull_request.yml
+++ b/.github/workflows/branch_dispatch_pull_request.yml
@@ -35,7 +35,7 @@ jobs:
       # always checkout the base branch of the PR to use trustful actions before the identity
       # could be verified.
       - name: Checkout commit sha (Pull Request only)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }} # Check out the base to use trustworthy actions
 
@@ -51,17 +51,16 @@ jobs:
         run: |
           echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_ENV
 
-      # Unbelievably, for pull requests only, there is apparently no way to get
-      # the commit message directly via the github API.
-      # See https://github.com/orgs/community/discussions/28474
-      - name: Checkout commit sha (Pull Request only)
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
+      # Fetch the head commit's subject line via the GitHub API (by SHA) instead of
+      # checking out the PR's fork content. We only need commit metadata, not the fork's
+      # files, so this avoids `actions/checkout`'s fork-PR safety guard (and the need to
+      # opt in to `allow-unsafe-pr-checkout`) entirely, regardless of the prior membership check.
       - name: Get commit message (Pull Request only)
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          echo "commit_message=$(git show -s --format=%s)" >> $GITHUB_ENV
+          subject=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" --jq '.commit.message' | head -n1)
+          echo "commit_message=$subject" >> "$GITHUB_ENV"
 
       - name: Check existence of Sophios
         uses: ./.github/my_actions/check_existence/ # Must start with ./

--- a/.github/workflows/branch_dispatch_push.yml
+++ b/.github/workflows/branch_dispatch_push.yml
@@ -25,7 +25,7 @@ jobs:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Check existence of Sophios
         uses: ./.github/my_actions/check_existence/ # Must start with ./

--- a/.github/workflows/branch_dispatch_repository_dispatch.yml
+++ b/.github/workflows/branch_dispatch_repository_dispatch.yml
@@ -36,7 +36,7 @@ jobs:
       # guarantee the subsequent workflows after workflow dispatch don't checkout altered actions.
       # Therefore, membership must be checked to authorize the repository dispatch to run workflows.
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # Note: It is the initial sender of the series of cross-repo CI who needs to verified, not the
       # sender of the current event. For example, the repository_dispatch event could be triggered by a

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -39,7 +39,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: sophios-wheels
             path: dist/*

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Docker Build
       run: cd docker/ && docker build --no-cache --pull -f Dockerfile_${{ matrix.dockerfile }} -t polusai/wic_${{ matrix.dockerfile }} ..

--- a/.github/workflows/docker_build_plugins.yml
+++ b/.github/workflows/docker_build_plugins.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Docker Build
       run: cd examples/scripts/ && docker build --no-cache --pull -f Dockerfile_${{ matrix.dockerfile }} -t polusai/wic_${{ matrix.dockerfile }} .

--- a/.github/workflows/fuzzy_compile_weekly.yml
+++ b/.github/workflows/fuzzy_compile_weekly.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout sophios
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/sophios
           ref: ${{ inputs.wic_ref }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Checkout biobb_adapters
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: vjaganat90/biobb_adapters
           ref: master
@@ -53,7 +53,7 @@ jobs:
 
       - name: Checkout mm-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/mm-workflows
           ref: ${{ inputs.mm-workflows_ref }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Checkout image-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/image-workflows
           ref: ${{ inputs.image-workflows_ref }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Checkout sophios
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.wic_owner }}/sophios
           ref: ${{ inputs.wic_ref }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Checkout biobb_adapters
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           # NOTE: temporarily hardcode sameeul & master because we can only
           # have up to 10 input parameters for workflow_dispatch
@@ -110,7 +110,7 @@ jobs:
 
       - name: Checkout mm-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.mm-workflows_owner }}/mm-workflows
           ref: ${{ inputs.mm-workflows_ref }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Checkout image-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.image-workflows_owner }}/image-workflows
           ref: ${{ inputs.image-workflows_ref }}

--- a/.github/workflows/lint_and_test_macos.yml
+++ b/.github/workflows/lint_and_test_macos.yml
@@ -37,15 +37,16 @@ jobs:
     steps:
       - name: Checkout sophios
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/sophios
           ref: master
           path: sophios
+          fetch-depth: 0 # setuptools-scm needs full history to resolve the version from tags
 
       - name: Checkout biobb_adapters
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: vjaganat90/biobb_adapters
           ref: master
@@ -53,7 +54,7 @@ jobs:
 
       - name: Checkout mm-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/mm-workflows
           ref: main
@@ -61,7 +62,7 @@ jobs:
 
       - name: Checkout image-workflows
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/image-workflows
           ref: main
@@ -86,6 +87,11 @@ jobs:
 
       - name: Install Sophios
         if: always()
+        # macos-latest runners can be slow enough that setuptools-scm's default 40s
+        # subprocess timeout (for its internal `git rev-parse HEAD` sanity check) is
+        # exceeded, failing the build with `subprocess.TimeoutExpired`. Raise it.
+        env:
+          SETUPTOOLS_SCM_SUBPROCESS_TIMEOUT: "120"
         run: cd sophios/ && pip install ".[all_except_runner_src]"
 
       - name: Update Sophios Config

--- a/.github/workflows/publish_rest_docker.yml
+++ b/.github/workflows/publish_rest_docker.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx 🐳
         uses: docker/setup-buildx-action@v1
@@ -23,15 +23,15 @@ jobs:
 
       - name: Print Tag
         run: echo "Publishing with tag ${{ env.tag }}"
-      
+
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Publish Sophios Container 🐳
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile_ubuntu_REST

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
       actions: write
     steps:
       - name: Trigger PyPI publish
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
     - name: Checkout sophios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ inputs.wic_owner }}/sophios
         ref: ${{ inputs.wic_ref }}
@@ -77,7 +77,7 @@ jobs:
 
     - name: Checkout biobb_adapters
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         # NOTE: temporarily hardcode sameeul & master because we can only
         # have up to 10 input parameters for workflow_dispatch...
@@ -87,7 +87,7 @@ jobs:
 
     - name: Checkout mm-workflows
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ inputs.mm-workflows_owner }}/mm-workflows
         ref: ${{ inputs.mm-workflows_ref }}
@@ -95,7 +95,7 @@ jobs:
 
     - name: Checkout image-workflows
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ inputs.image-workflows_owner }}/image-workflows
         ref: ${{ inputs.image-workflows_ref }}

--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout sophios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ github.repository_owner }}/sophios
         ref: master
@@ -43,7 +43,7 @@ jobs:
 
     - name: Checkout biobb_adapters
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: vjaganat90/biobb_adapters
         ref: master
@@ -51,7 +51,7 @@ jobs:
 
     - name: Checkout mm-workflows
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ github.repository_owner }}/mm-workflows
         ref: main
@@ -59,7 +59,7 @@ jobs:
 
     - name: Checkout image-workflows
       if: always()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: ${{ github.repository_owner }}/image-workflows
         ref: main

--- a/.github/workflows/test_and_publish_pypi.yml
+++ b/.github/workflows/test_and_publish_pypi.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -48,7 +48,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: sophios-wheels
             path: dist/*


### PR DESCRIPTION
_This PR includes the branch dispatch/old node failure. That change needs to land upstream for the branch dispatch action to be green._

This PR updates the GitHub Actions dependencies used across Sophios CI and repository automation. It also fixes the macOS lint-and-test workflow by installing the system dependencies required by the test environment. No application code is changed. This is the base PR for the subsequent bug-fix and refactoring work.