### PR TITLE
fix: Deduplicate unlabeled Graphviz edges

### DIFF
--- a/src/sophios/utils_graphs.py
+++ b/src/sophios/utils_graphs.py
@@ -35,6 +35,16 @@ def add_graph_edge(graph_settings: Dict[str, Any], graph: GraphReps,
     graph_gv = graph.graphviz
     graph_nx = graph.networkx
     graphdata = graph.graphdata
+    edge_exists = graph_nx.has_edge(edge_node1, edge_node2)
+
+    # A workflow can connect several ports between the same pair of steps. At
+    # the collapsed step level those connections describe one dependency, and
+    # drawing each port connection as a separate unlabeled edge produces
+    # indistinguishable parallel arrows. Preserve parallel edges when labels
+    # are requested because the labels carry the port-level distinction.
+    if edge_exists and not graph_settings['graph_label_edges']:
+        return
+
     attrs = {}
     # Hide internal self-edges
     if edge_node1 != edge_node2:

--- a/tests/test_utils_graphs.py
+++ b/tests/test_utils_graphs.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from sophios.utils_graphs import add_graph_edge, get_graph_reps
+
+
+def _graph_settings(*, label_edges: bool) -> dict[str, Any]:
+    return {
+        'graph_dark_theme': False,
+        'graph_inline_depth': 1,
+        'graph_label_edges': label_edges,
+        'graph_label_stepname': False,
+        'graph_show_inputs': False,
+        'graph_show_outputs': False,
+    }
+
+
+def test_unlabeled_graph_deduplicates_collapsed_step_dependencies() -> None:
+    """Multiple port links should render as one unlabeled step dependency."""
+    graph = get_graph_reps('workflow')
+    settings = _graph_settings(label_edges=False)
+
+    add_graph_edge(settings, graph, ['workflow', 'prepare'], ['workflow', 'report'], 'summary')
+    add_graph_edge(settings, graph, ['workflow', 'prepare'], ['workflow', 'report'], 'status')
+
+    graphviz_edges = [line for line in graph.graphviz.body if '->' in line]
+    assert len(graphviz_edges) == 1
+    assert len(graph.graphdata.edges) == 1
+    assert list(graph.networkx.edges) == [('workflow___prepare', 'workflow___report')]
+
+
+def test_labeled_graph_preserves_port_level_edges() -> None:
+    """Port labels should preserve distinct connections between the same steps."""
+    graph = get_graph_reps('workflow')
+    settings = _graph_settings(label_edges=True)
+
+    add_graph_edge(settings, graph, ['workflow', 'prepare'], ['workflow', 'report'], 'summary')
+    add_graph_edge(settings, graph, ['workflow', 'prepare'], ['workflow', 'report'], 'status')
+
+    graphviz_edges = [line for line in graph.graphviz.body if '->' in line]
+    assert len(graphviz_edges) == 2
+    assert len(graph.graphdata.edges) == 2


### PR DESCRIPTION
This is a minor but important fix where generated workflow graph (--graphviz) has incorrect duplicate arrows (edges) joining the same two pair of steps. This was unearthed while creating an example for conditional workflows using sophios Python API. NetworkX and stored graph metadata remain consistent with the rendered graph.

We still preserve the ability to have duplicate edges or truly unique paths if there are port-level labels.