### PR TITLE
feat: compile Sophios workflows to Nextflow IR

### DIFF
--- a/codespellwords.txt
+++ b/codespellwords.txt
@@ -2,3 +2,4 @@ equil
 Equil
 nin
 namd
+nd

--- a/src/sophios/nf_symbols.py
+++ b/src/sophios/nf_symbols.py
@@ -1,0 +1,201 @@
+"""Nextflow symbol rules derived from the pinned Nextflow language grammar."""
+
+from unicodedata import category
+
+
+NEXTFLOW_GRAMMAR_VERSION = "26.04.2"
+
+# Sources pinned to the runtime version used by this backend:
+# - modules/nf-lang/src/main/antlr/ScriptLexer.g4, JavaLetter and
+#   JavaLetterOrDigit
+# - modules/nf-lang/src/main/antlr/ScriptParser.g4, identifier
+# - modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java,
+#   checkInvalidVarName and GROOVY_KEYWORDS
+_NEXTFLOW_GRAMMAR_ROOT = (
+    "https://github.com/nextflow-io/nextflow/blob/v26.04.2/"
+    "modules/nf-lang/src/main"
+)
+NEXTFLOW_LEXER_SOURCE = f"{_NEXTFLOW_GRAMMAR_ROOT}/antlr/ScriptLexer.g4"
+NEXTFLOW_PARSER_SOURCE = f"{_NEXTFLOW_GRAMMAR_ROOT}/antlr/ScriptParser.g4"
+NEXTFLOW_SEMANTICS_SOURCE = (
+    f"{_NEXTFLOW_GRAMMAR_ROOT}/java/nextflow/script/parser/ScriptAstBuilder.java"
+)
+
+# ScriptParser.identifier explicitly admits these keyword tokens as symbols.
+NEXTFLOW_IDENTIFIER_KEYWORDS = frozenset(
+    {
+        "in",
+        "nextflow",
+        "params",
+        "from",
+        "record",
+        "process",
+        "exec",
+        "input",
+        "output",
+        "script",
+        "shell",
+        "stage",
+        "stub",
+        "topic",
+        "tuple",
+        "when",
+        "workflow",
+        "emit",
+        "main",
+        "onComplete",
+        "onError",
+        "publish",
+        "take",
+    }
+)
+
+# Word-shaped tokens declared before Identifier in ScriptLexer.
+_NEXTFLOW_LEXER_WORDS = frozenset(
+    {
+        "as",
+        "def",
+        "in",
+        "assert",
+        "boolean",
+        "byte",
+        "catch",
+        "char",
+        "double",
+        "else",
+        "enum",
+        "float",
+        "if",
+        "import",
+        "instanceof",
+        "int",
+        "long",
+        "new",
+        "record",
+        "return",
+        "short",
+        "throw",
+        "try",
+        "nextflow",
+        "params",
+        "include",
+        "from",
+        "process",
+        "exec",
+        "input",
+        "output",
+        "script",
+        "shell",
+        "stage",
+        "stub",
+        "topic",
+        "tuple",
+        "when",
+        "workflow",
+        "emit",
+        "main",
+        "onComplete",
+        "onError",
+        "publish",
+        "take",
+    }
+)
+
+# ScriptAstBuilder rejects these when a symbol is used as a variable/callable.
+_GROOVY_KEYWORDS = frozenset(
+    {
+        "abstract",
+        "assert",
+        "break",
+        "case",
+        "class",
+        "const",
+        "continue",
+        "default",
+        "do",
+        "extends",
+        "final",
+        "finally",
+        "for",
+        "goto",
+        "implements",
+        "interface",
+        "native",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "static",
+        "super",
+        "switch",
+        "synchronized",
+        "this",
+        "throws",
+        "transient",
+        "void",
+        "volatile",
+        "while",
+    }
+)
+
+NEXTFLOW_RESERVED_WORDS = (
+    _NEXTFLOW_LEXER_WORDS
+    | _GROOVY_KEYWORDS
+    | {"true", "false", "null", "_"}
+) - NEXTFLOW_IDENTIFIER_KEYWORDS
+
+# ScriptLexer.JavaLetter delegates to Character.isJavaIdentifierStart and
+# excludes identifier-ignorable characters. These Unicode general categories
+# are the corresponding Java identifier categories.
+_JAVA_LETTER_CATEGORIES = frozenset({"Lu", "Ll", "Lt", "Lm", "Lo", "Nl", "Sc", "Pc"})
+_JAVA_LETTER_OR_DIGIT_CATEGORIES = _JAVA_LETTER_CATEGORIES | {"Nd", "Mc", "Mn"}
+
+
+def _is_java_letter(character: str) -> bool:
+    return category(character) in _JAVA_LETTER_CATEGORIES
+
+
+def _is_java_letter_or_digit(character: str) -> bool:
+    return category(character) in _JAVA_LETTER_OR_DIGIT_CATEGORIES
+
+
+def is_nextflow_identifier(value: object) -> bool:
+    """Return whether a value is a callable symbol in the Nextflow grammar."""
+    match value:
+        case str() as identifier if identifier and identifier not in NEXTFLOW_RESERVED_WORDS:
+            return _is_java_letter(identifier[0]) and all(
+                _is_java_letter_or_digit(character) for character in identifier[1:]
+            )
+        case _:
+            return False
+
+
+def validate_nextflow_identifier(value: object, *, field_name: str) -> str:
+    """Return a valid Nextflow symbol or raise a grammar-specific error."""
+    match value:
+        case str() as identifier if is_nextflow_identifier(identifier):
+            return identifier
+        case _:
+            raise ValueError(
+                f"{field_name} must be a valid Nextflow identifier per the "
+                f"Nextflow {NEXTFLOW_GRAMMAR_VERSION} grammar, got {value!r}"
+            )
+
+
+def normalize_nextflow_identifier(value: object) -> str:
+    """Normalize text to a callable identifier using Nextflow grammar symbols."""
+    match value:
+        case str() as source if source:
+            pass
+        case _:
+            raise ValueError("Nextflow identifier source must be a non-empty string")
+
+    identifier = "".join(
+        character if _is_java_letter_or_digit(character) else "_"
+        for character in source
+    )
+    if not _is_java_letter(identifier[0]):
+        identifier = f"_{identifier}"
+    if identifier in NEXTFLOW_RESERVED_WORDS:
+        identifier = f"_{identifier}"
+    return validate_nextflow_identifier(identifier, field_name="normalized identifier")

--- a/src/sophios/nf_types.py
+++ b/src/sophios/nf_types.py
@@ -1,0 +1,320 @@
+"""Validated intermediate-representation types for Nextflow DSL2 support."""
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+import json
+from typing import Any, ClassVar, Self
+
+from .nf_symbols import validate_nextflow_identifier
+
+
+def _validate_string_mapping(value: Mapping[str, str], *, field_name: str) -> None:
+    for key, item in value.items():
+        match key, item:
+            case str() as name, str() if name:
+                continue
+            case str() as name, _ if name:
+                raise ValueError(f"{field_name}[{name!r}] must be a string")
+            case _:
+                raise ValueError(f"{field_name} keys must be non-empty strings")
+
+
+def _mapping(value: Any, *, type_name: str) -> Mapping[str, Any]:
+    match value:
+        case Mapping() as item:
+            return item
+        case _:
+            raise TypeError(f"{type_name} hydration requires a mapping")
+
+
+def _check_fields(
+    value: Mapping[str, Any],
+    *,
+    type_name: str,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> None:
+    optional_fields = optional or set()
+    missing = required - set(value)
+    unknown = set(value) - required - optional_fields
+    if missing:
+        raise ValueError(f"{type_name} is missing required fields: {', '.join(sorted(missing))}")
+    if unknown:
+        raise ValueError(f"{type_name} has unknown fields: {', '.join(sorted(unknown))}")
+
+
+@dataclass(frozen=True, slots=True)
+class NfPort:
+    """A typed Nextflow process port."""
+
+    ALLOWED_QUALIFIERS: ClassVar[frozenset[str]] = frozenset({"path", "val", "tuple", "env", "stdin"})
+
+    name: str
+    qualifier: str
+    emit: str | None = None
+
+    def __post_init__(self) -> None:
+        validate_nextflow_identifier(self.name, field_name="port name")
+        if self.qualifier not in self.ALLOWED_QUALIFIERS:
+            allowed = ", ".join(sorted(self.ALLOWED_QUALIFIERS))
+            raise ValueError(f"port qualifier must be one of {allowed}, got {self.qualifier!r}")
+        if self.emit is not None:
+            validate_nextflow_identifier(self.emit, field_name="port emit")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Hydrate and validate a port from a mapping."""
+        item = _mapping(value, type_name=cls.__name__)
+        _check_fields(item, type_name=cls.__name__, required={"name", "qualifier", "emit"})
+        return cls(name=item["name"], qualifier=item["qualifier"], emit=item["emit"])
+
+
+def _validate_port_list(value: Any, *, kind: str) -> None:
+    match value:
+        case list() as ports:
+            for port in ports:
+                match port:
+                    case NfPort():
+                        continue
+                    case _:
+                        raise TypeError(f"process {kind} must be a list of NfPort values")
+        case _:
+            raise TypeError(f"process {kind} must be a list of NfPort values")
+
+
+@dataclass(frozen=True, slots=True)
+class NfProcess:
+    """A Nextflow process and the supported execution metadata needed to render it."""
+
+    name: str
+    inputs: list[NfPort]
+    outputs: list[NfPort]
+    script: str
+    container: str | None = None
+    directives: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_nextflow_identifier(self.name, field_name="process name")
+        _validate_port_list(self.inputs, kind="inputs")
+        _validate_port_list(self.outputs, kind="outputs")
+        for kind, ports in (("input", self.inputs), ("output", self.outputs)):
+            names = [port.name for port in ports]
+            if len(names) != len(set(names)):
+                raise ValueError(f"process {self.name!r} has duplicate {kind} port names")
+        if any(port.emit is not None for port in self.inputs):
+            raise ValueError("process input ports cannot declare emit names")
+        match self.script:
+            case str() as script if script.strip():
+                pass
+            case _:
+                raise ValueError("process script must be a non-empty string")
+        match self.container:
+            case None:
+                pass
+            case str() as container if container.strip():
+                pass
+            case _:
+                raise ValueError("process container must be a non-empty string or None")
+        match self.directives:
+            case dict():
+                pass
+            case _:
+                raise TypeError("process directives must be a dictionary")
+        _validate_string_mapping(self.directives, field_name="process directives")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Hydrate and validate a process from a mapping."""
+        item = _mapping(value, type_name=cls.__name__)
+        _check_fields(
+            item,
+            type_name=cls.__name__,
+            required={"name", "inputs", "outputs", "script", "container", "directives"},
+        )
+        match item["inputs"], item["outputs"]:
+            case list() as inputs, list() as outputs:
+                return cls(
+                    name=item["name"],
+                    inputs=[NfPort.from_dict(port) for port in inputs],
+                    outputs=[NfPort.from_dict(port) for port in outputs],
+                    script=item["script"],
+                    container=item["container"],
+                    directives=dict(item["directives"]),
+                )
+            case _:
+                raise TypeError("NfProcess inputs and outputs must be lists")
+
+
+@dataclass(frozen=True, slots=True)
+class NfConnection:
+    """A directed edge between a workflow boundary and/or two process ports."""
+
+    from_process: str | None
+    from_port: str
+    to_process: str | None
+    to_port: str
+
+    def __post_init__(self) -> None:
+        if self.from_process is not None:
+            validate_nextflow_identifier(self.from_process, field_name="connection source process")
+        if self.to_process is not None:
+            validate_nextflow_identifier(self.to_process, field_name="connection destination process")
+        validate_nextflow_identifier(self.from_port, field_name="connection source port")
+        validate_nextflow_identifier(self.to_port, field_name="connection destination port")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Hydrate and validate a connection from a mapping."""
+        item = _mapping(value, type_name=cls.__name__)
+        _check_fields(
+            item,
+            type_name=cls.__name__,
+            required={"from_process", "from_port", "to_process", "to_port"},
+        )
+        return cls(
+            from_process=item["from_process"],
+            from_port=item["from_port"],
+            to_process=item["to_process"],
+            to_port=item["to_port"],
+        )
+
+
+def _validate_workflow_items(processes: Any, connections: Any) -> None:
+    match processes:
+        case list() as process_list:
+            for process in process_list:
+                match process:
+                    case NfProcess():
+                        continue
+                    case _:
+                        raise TypeError("workflow processes must be a list of NfProcess values")
+        case _:
+            raise TypeError("workflow processes must be a list of NfProcess values")
+
+    match connections:
+        case list() as connection_list:
+            for connection in connection_list:
+                match connection:
+                    case NfConnection():
+                        continue
+                    case _:
+                        raise TypeError("workflow connections must be a list of NfConnection values")
+        case _:
+            raise TypeError("workflow connections must be a list of NfConnection values")
+
+
+@dataclass(frozen=True, slots=True)
+class NextflowWorkflow:
+    """Validated, JSON-hydratable intermediate representation of a DSL2 workflow."""
+
+    name: str
+    processes: list[NfProcess]
+    connections: list[NfConnection]
+    params: dict[str, Any]
+    directives: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_nextflow_identifier(self.name, field_name="workflow name")
+        _validate_workflow_items(self.processes, self.connections)
+        match self.params, self.directives:
+            case dict(), dict():
+                pass
+            case dict(), _:
+                raise TypeError("workflow directives must be a dictionary")
+            case _:
+                raise TypeError("workflow params must be a dictionary")
+        _validate_string_mapping(self.directives, field_name="workflow directives")
+        try:
+            json.dumps(self.params, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("workflow params must contain JSON-compatible values") from exc
+        self._validate_processes_and_connections()
+
+    def _validate_processes_and_connections(self) -> None:
+        process_by_name = {process.name: process for process in self.processes}
+        if len(process_by_name) != len(self.processes):
+            raise ValueError("workflow contains a duplicate process name")
+        if len(set(self.connections)) != len(self.connections):
+            raise ValueError("workflow contains a duplicate connection")
+
+        for connection in self.connections:
+            destination = None
+            if connection.to_process is not None:
+                destination = process_by_name.get(connection.to_process)
+                if destination is None:
+                    raise ValueError(f"connection references unknown destination process {connection.to_process!r}")
+                if connection.to_port not in {port.name for port in destination.inputs}:
+                    raise ValueError(
+                        f"connection references unknown input port "
+                        f"{connection.to_process}.{connection.to_port}"
+                    )
+
+            if connection.from_process is None:
+                if connection.from_port not in self.params:
+                    raise ValueError(f"connection references unknown workflow input {connection.from_port!r}")
+                continue
+
+            source = process_by_name.get(connection.from_process)
+            if source is None:
+                raise ValueError(f"connection references unknown source process {connection.from_process!r}")
+            if connection.from_port not in {port.name for port in source.outputs}:
+                raise ValueError(
+                    f"connection references unknown output port "
+                    f"{connection.from_process}.{connection.from_port}"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Serialize this workflow deterministically."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True, allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Hydrate and validate a workflow from a mapping."""
+        item = _mapping(value, type_name=cls.__name__)
+        _check_fields(
+            item,
+            type_name=cls.__name__,
+            required={"name", "processes", "connections", "params"},
+            optional={"directives"},
+        )
+        match item["processes"], item["connections"]:
+            case list() as processes, list() as connections:
+                return cls(
+                    name=item["name"],
+                    processes=[NfProcess.from_dict(process) for process in processes],
+                    connections=[NfConnection.from_dict(connection) for connection in connections],
+                    params=dict(item["params"]),
+                    directives=dict(item.get("directives", {})),
+                )
+            case _:
+                raise TypeError("NextflowWorkflow processes and connections must be lists")
+
+    @classmethod
+    def from_json(cls, value: str) -> Self:
+        """Hydrate and validate a workflow from JSON text."""
+        match value:
+            case str():
+                pass
+            case _:
+                raise TypeError("NextflowWorkflow JSON input must be a string")
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid NextflowWorkflow JSON") from exc
+        return cls.from_dict(parsed)

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -1,0 +1,592 @@
+"""Convert compiled Sophios RoseTrees into the Nextflow intermediate representation."""
+
+from collections.abc import Mapping
+import copy
+import json
+from os import PathLike
+import re
+import shlex
+from typing import Any
+
+from .nf_symbols import normalize_nextflow_identifier
+from .nf_types import NfConnection, NfPort, NfProcess, NextflowWorkflow
+from .wic_types import NodeData, RoseTree
+
+
+def _identifier(value: Any, *, context: str) -> str:
+    """Normalize a CWL identifier into a stable Nextflow identifier."""
+    match value:
+        case str() if value:
+            pass
+        case _:
+            raise ValueError(f"{context} must be a non-empty string")
+    local = value.rsplit("#", maxsplit=1)[-1]
+    if not local:
+        raise ValueError(f"{context} cannot be normalized to a Nextflow identifier")
+    return normalize_nextflow_identifier(local)
+
+
+def _as_mapping(value: Any, *, error: str) -> Mapping[str, Any]:
+    match value:
+        case Mapping() as mapping:
+            return mapping
+        case _:
+            raise ValueError(error)
+
+
+def _as_list(value: Any, *, error: str) -> list[Any]:
+    match value:
+        case list() as items:
+            return items
+        case _:
+            raise ValueError(error)
+
+
+def _is_optional(cwl_type: Any) -> bool:
+    match cwl_type:
+        case str() as type_name:
+            return type_name.endswith("?")
+        case list() as union:
+            return "null" in union
+        case _:
+            return False
+
+
+def _required_type(cwl_type: Any) -> Any:
+    match cwl_type:
+        case str() as type_name if type_name.endswith("?"):
+            return type_name[:-1]
+        case list() as union if "null" in union:
+            remaining = [item for item in union if item != "null"]
+            if len(remaining) != 1:
+                raise ValueError(f"unsupported optional CWL union {cwl_type!r}")
+            return remaining[0]
+        case _:
+            return cwl_type
+
+
+def cwl_type_to_nf_qualifier(cwl_type: Any) -> str:
+    """Map the documented Phase 1 CWL type subset to a Nextflow qualifier."""
+    if _is_optional(cwl_type):
+        return "val"
+    match _required_type(cwl_type):
+        case "File" | "Directory" | "File[]":
+            return "path"
+        case "string" | "int" | "float" | "boolean" | "Any":
+            return "val"
+        case {"type": "array", "items": "File"}:
+            return "path"
+        case _:
+            raise ValueError(f"unsupported CWL type for Nextflow Phase 1: {cwl_type!r}")
+
+
+def _ports(raw_ports: Any, *, outputs: bool) -> list[NfPort]:
+    port_definitions = _as_mapping(raw_ports, error="CommandLineTool ports must be a mapping")
+    ports: list[NfPort] = []
+    for raw_name, raw_definition in port_definitions.items():
+        match raw_definition:
+            case {"type": cwl_type}:
+                name = _identifier(raw_name, context="port name")
+                ports.append(
+                    NfPort(
+                        name,
+                        cwl_type_to_nf_qualifier(cwl_type),
+                        emit=name if outputs else None,
+                    )
+                )
+            case _:
+                raise ValueError(f"CWL port {raw_name!r} must declare a type")
+    return ports
+
+
+_INPUT_EXPRESSION = re.compile(
+    r"\$\(\s*inputs\.([A-Za-z_][A-Za-z0-9_]*)(?:\.(?:path|basename))?\s*\)"
+)
+
+
+def _translate_input_expressions(value: str) -> str:
+    return _INPUT_EXPRESSION.sub(lambda match: f"${_identifier(match.group(1), context='input reference')}", value)
+
+
+def _shell_literal(value: Any) -> str:
+    match value:
+        case bool() as boolean:
+            return "true" if boolean else "false"
+        case (int() | float()) as number:
+            return str(number)
+        case str() as text:
+            translated = _translate_input_expressions(text)
+            if "$" in translated or any(character.isspace() for character in translated):
+                return translated if "$" in translated else shlex.quote(translated)
+            return shlex.quote(translated)
+        case _:
+            raise ValueError(f"unsupported CWL command value {value!r}")
+
+
+def _position(value: Any, *, default: int) -> int:
+    match value:
+        case None:
+            return default
+        case int() as position:
+            return position
+        case str() as position:
+            try:
+                return int(position)
+            except ValueError as exc:
+                raise ValueError(f"unsupported non-integer CWL command position {value!r}") from exc
+        case _:
+            raise ValueError(f"unsupported CWL command position {value!r}")
+
+
+def _binding_token(prefix: Any, value: str, *, separate: Any = True) -> str:
+    match prefix:
+        case None:
+            return value
+        case str() as text:
+            rendered_prefix = shlex.quote(text)
+            return f"{rendered_prefix} {value}" if separate is not False else f"{rendered_prefix}{value}"
+        case _:
+            raise ValueError("CWL command prefix must be a string")
+
+
+def _argument_items(arguments: list[Any]) -> list[tuple[int, int, str]]:
+    items: list[tuple[int, int, str]] = []
+    for index, argument in enumerate(arguments):
+        match argument:
+            case {"valueFrom": value_from}:
+                value = _shell_literal(value_from)
+                token = _binding_token(argument.get("prefix"), value, separate=argument.get("separate", True))
+                item_position = _position(argument.get("position"), default=index)
+            case Mapping():
+                raise ValueError("mapped CWL arguments must contain valueFrom")
+            case _:
+                token = _shell_literal(argument)
+                item_position = index
+        items.append((item_position, index, token))
+    return items
+
+
+def _input_binding_items(
+    inputs: Mapping[str, Any],
+    *,
+    start: int,
+) -> list[tuple[int, int, str]]:
+    items: list[tuple[int, int, str]] = []
+    for index, (raw_name, definition) in enumerate(inputs.items(), start=start):
+        input_definition = _as_mapping(definition, error=f"CWL input {raw_name!r} must be a mapping")
+        match input_definition.get("inputBinding"):
+            case None:
+                continue
+            case Mapping() as binding:
+                pass
+            case _:
+                raise ValueError(f"CWL inputBinding for {raw_name!r} must be a mapping")
+        name = _identifier(raw_name, context="input binding name")
+        value_from = binding.get("valueFrom")
+        value = _shell_literal(value_from) if value_from is not None else f"${name}"
+        token = _binding_token(binding.get("prefix"), value, separate=binding.get("separate", True))
+        items.append((_position(binding.get("position"), default=index), index, token))
+    return items
+
+
+def _command_items(tool: Mapping[str, Any]) -> list[tuple[int, int, str]]:
+    arguments = _as_list(tool.get("arguments", []), error="CommandLineTool arguments must be a list")
+    inputs = _as_mapping(tool.get("inputs", {}), error="CommandLineTool inputs must be a mapping")
+    return sorted(
+        [
+            *_argument_items(arguments),
+            *_input_binding_items(inputs, start=len(arguments)),
+        ]
+    )
+
+
+def _script(tool: Mapping[str, Any]) -> str:
+    base_command = tool.get("baseCommand")
+    tokens: list[str] = []
+    match base_command:
+        case str() as command if command:
+            tokens.append(shlex.quote(command))
+        case list() as command:
+            for token in command:
+                match token:
+                    case str():
+                        tokens.append(shlex.quote(token))
+                    case _:
+                        raise ValueError("CommandLineTool baseCommand must be a string or list of strings")
+        case None:
+            pass
+        case _:
+            raise ValueError("CommandLineTool baseCommand must be a string or list of strings")
+
+    tokens.extend(token for _position_value, _sequence, token in _command_items(tool))
+    command = " ".join(tokens) or "true"
+    stdin = tool.get("stdin")
+    stdout = tool.get("stdout")
+    stderr = tool.get("stderr")
+    if stdin is not None:
+        command += f" < {_shell_literal(stdin)}"
+    if stdout is not None:
+        command += f" > {_shell_literal(stdout)}"
+    if stderr is not None:
+        command += f" 2> {_shell_literal(stderr)}"
+    return command
+
+
+def _requirement(tool: Mapping[str, Any], class_name: str) -> Mapping[str, Any] | None:
+    for section_name in ("requirements", "hints"):
+        section = tool.get(section_name, {})
+        match section:
+            case None:
+                continue
+            case Mapping() as requirements:
+                match requirements.get(class_name):
+                    case None:
+                        continue
+                    case Mapping() as requirement:
+                        return requirement
+                    case _:
+                        raise ValueError(f"{class_name} must be a mapping")
+            case list() as requirements:
+                for requirement in requirements:
+                    match requirement:
+                        case Mapping() if requirement.get("class") == class_name:
+                            return requirement
+                        case _:
+                            continue
+            case _:
+                raise ValueError(f"CommandLineTool {section_name} must be a mapping or list")
+    return None
+
+
+def _container(tool: Mapping[str, Any]) -> str | None:
+    docker = _requirement(tool, "DockerRequirement")
+    if docker is None:
+        return None
+    match docker.get("dockerPull", docker.get("dockerImageId")):
+        case str() as image if image:
+            return image
+        case _:
+            raise ValueError("DockerRequirement must define dockerPull or dockerImageId")
+
+
+def _resource_value(resource: Mapping[str, Any], minimum: str, maximum: str) -> Any:
+    return resource.get(minimum, resource.get(maximum))
+
+
+def _render_resource(value: Any, *, name: str) -> str:
+    match value:
+        case bool():
+            raise ValueError(f"{name} resource requirement must be numeric")
+        case float() as number if number.is_integer():
+            return str(int(number))
+        case (int() | float()) as number:
+            return str(number)
+        case _:
+            raise ValueError(f"{name} resource requirement must be numeric")
+
+
+def _resource_directives(tool: Mapping[str, Any]) -> dict[str, str]:
+    resource = _requirement(tool, "ResourceRequirement")
+    if resource is None:
+        return {}
+    directives: dict[str, str] = {}
+    if (cpus := _resource_value(resource, "coresMin", "coresMax")) is not None:
+        directives["cpus"] = _render_resource(cpus, name="CPU")
+    if (memory := _resource_value(resource, "ramMin", "ramMax")) is not None:
+        directives["memory"] = f"{_render_resource(memory, name='memory')} MB"
+    return directives
+
+
+def _optional_input_directive(tool: Mapping[str, Any]) -> str | None:
+    inputs = _as_mapping(tool.get("inputs", {}), error="CommandLineTool inputs must be a mapping")
+    optional_inputs: list[str] = []
+    for name, definition in inputs.items():
+        match definition:
+            case Mapping() as input_definition if _is_optional(input_definition.get("type")):
+                optional_inputs.append(_identifier(name, context="optional input name"))
+            case _:
+                continue
+    return ",".join(optional_inputs) or None
+
+
+def _output_glob_directives(tool: Mapping[str, Any]) -> dict[str, str]:
+    outputs = _as_mapping(tool.get("outputs", {}), error="CommandLineTool outputs must be a mapping")
+    directives: dict[str, str] = {}
+    for raw_name, definition in outputs.items():
+        output_definition = _as_mapping(definition, error=f"CWL output {raw_name!r} must be a mapping")
+        match output_definition.get("outputBinding"):
+            case None:
+                continue
+            case Mapping() as binding:
+                pass
+            case _:
+                raise ValueError(f"CWL outputBinding for {raw_name!r} must be a mapping")
+        match binding.get("glob"):
+            case None:
+                continue
+            case str() as glob:
+                rendered_glob = glob
+            case list() as glob:
+                rendered_glob = json.dumps(glob, sort_keys=True)
+            case _:
+                raise ValueError(f"CWL output glob for {raw_name!r} must be a string or list")
+        directives[f"_output_glob.{_identifier(raw_name, context='output name')}"] = rendered_glob
+    return directives
+
+
+def _directives(tool: Mapping[str, Any]) -> dict[str, str]:
+    directives = _resource_directives(tool)
+    if optional_inputs := _optional_input_directive(tool):
+        directives["_optional_inputs"] = optional_inputs
+    directives.update(_output_glob_directives(tool))
+    return directives
+
+
+def _scatter_inputs(value: Any) -> list[str]:
+    match value:
+        case None:
+            return []
+        case str() as scatter:
+            return [scatter]
+        case list() as scatter if scatter:
+            inputs: list[str] = []
+            for item in scatter:
+                match item:
+                    case str():
+                        inputs.append(item)
+                    case _:
+                        raise ValueError("CWL scatter must be a port name or non-empty list of port names")
+            return inputs
+        case _:
+            raise ValueError("CWL scatter must be a port name or non-empty list of port names")
+
+
+def _scatter_directives(step: Mapping[str, Any], tool: Mapping[str, Any]) -> dict[str, str]:
+    scatter_inputs = _scatter_inputs(step.get("scatter"))
+    if not scatter_inputs:
+        return {}
+    process_inputs = _as_mapping(tool.get("inputs", {}), error="CommandLineTool inputs must be a mapping")
+    input_names = {_identifier(name, context="scatter process input") for name in process_inputs}
+    normalized_scatter = [_identifier(name, context="scatter input") for name in scatter_inputs]
+    if missing := set(normalized_scatter) - input_names:
+        raise ValueError(f"scatter references unknown process inputs: {', '.join(sorted(missing))}")
+    match step.get("scatterMethod", "dotproduct"):
+        case str() as scatter_method if scatter_method:
+            return {
+                "_scatter": "true",
+                "_scatter_inputs": ",".join(normalized_scatter),
+                "_scatter_method": scatter_method,
+            }
+        case _:
+            raise ValueError("CWL scatterMethod must be a non-empty string")
+
+
+def _process(step: Mapping[str, Any], child: RoseTree) -> NfProcess:
+    match child:
+        case RoseTree(data=NodeData() as node_data, sub_trees=sub_trees):
+            pass
+        case _:
+            raise TypeError("each compiled workflow step must have a RoseTree[NodeData] child")
+    if "when" in step:
+        raise ValueError("CWL step when conditions are not supported in Nextflow Phase 1")
+    if sub_trees:
+        raise ValueError("nested workflows are deferred to Phase 2")
+    match node_data.compiled_cwl:
+        case Mapping() as tool:
+            pass
+        case _:
+            raise ValueError("compiled CommandLineTool must be a mapping")
+    match tool.get("class"):
+        case "Workflow":
+            raise ValueError("nested workflows are deferred to Phase 2")
+        case "CommandLineTool":
+            pass
+        case unsupported_class:
+            raise ValueError(f"unsupported compiled step class {unsupported_class!r}")
+    directives = _directives(tool)
+    directives.update(_scatter_directives(step, tool))
+
+    return NfProcess(
+        name=_identifier(step.get("id"), context="workflow step id"),
+        inputs=_ports(tool.get("inputs", {}), outputs=False),
+        outputs=_ports(tool.get("outputs", {}), outputs=True),
+        script=_script(tool),
+        container=_container(tool),
+        directives=directives,
+    )
+
+
+def _source_values(value: Any, *, context: str) -> list[str]:
+    match value:
+        case str() as source:
+            return [source]
+        case list() as sources if sources:
+            normalized: list[str] = []
+            for source in sources:
+                match source:
+                    case str():
+                        normalized.append(source)
+                    case _:
+                        raise ValueError(f"{context} must be a source string or list of source strings")
+            return normalized
+        case {"source": source} as source_definition:
+            unsupported = set(source_definition) - {"source"}
+            if unsupported:
+                raise ValueError(f"unsupported {context} fields: {', '.join(sorted(unsupported))}")
+            return _source_values(source, context=context)
+        case Mapping():
+            raise ValueError(f"{context} must define source")
+        case _:
+            raise ValueError(f"{context} must be a source string or list of source strings")
+
+
+def _step_name_map(steps: list[Mapping[str, Any]], processes: list[NfProcess]) -> dict[str, str]:
+    names: dict[str, str] = {}
+    for step, process in zip(steps, processes, strict=True):
+        match step.get("id"):
+            case str() as raw_name:
+                pass
+            case _:
+                raise ValueError("workflow step id must be a string")
+        for candidate in (raw_name, raw_name.rsplit("#", maxsplit=1)[-1]):
+            if candidate in names and names[candidate] != process.name:
+                raise ValueError(f"workflow step identifier {candidate!r} is ambiguous")
+            names[candidate] = process.name
+    return names
+
+
+def _source_endpoint(source: str, step_names: Mapping[str, str]) -> tuple[str | None, str]:
+    if "/" not in source:
+        return None, _identifier(source, context="workflow input source")
+    raw_process, raw_port = source.rsplit("/", maxsplit=1)
+    process = step_names.get(raw_process, step_names.get(raw_process.rsplit("#", maxsplit=1)[-1]))
+    if process is None:
+        raise ValueError(f"connection references unknown source process {raw_process!r}")
+    return process, _identifier(raw_port, context="process output source")
+
+
+def _step_connections(
+    steps: list[Mapping[str, Any]],
+    processes: list[NfProcess],
+    step_names: Mapping[str, str],
+) -> list[NfConnection]:
+    connections: list[NfConnection] = []
+    for step, process in zip(steps, processes, strict=True):
+        match step.get("in", {}):
+            case Mapping() as raw_inputs:
+                pass
+            case _:
+                raise ValueError(f"compiled step {process.name!r} inputs must be a mapping")
+        for raw_port, raw_source in raw_inputs.items():
+            destination_port = _identifier(raw_port, context="process input destination")
+            for source in _source_values(raw_source, context=f"step input {process.name}.{destination_port}"):
+                source_process, source_port = _source_endpoint(source, step_names)
+                connections.append(NfConnection(source_process, source_port, process.name, destination_port))
+    return connections
+
+
+def _workflow_output_connections(
+    workflow: Mapping[str, Any],
+    step_names: Mapping[str, str],
+) -> list[NfConnection]:
+    connections: list[NfConnection] = []
+    match workflow.get("outputs", {}):
+        case Mapping() as raw_outputs:
+            pass
+        case _:
+            raise ValueError("compiled CWL Workflow outputs must be a mapping")
+    for raw_port, definition in raw_outputs.items():
+        match definition:
+            case {"outputSource": output_source}:
+                destination_port = _identifier(raw_port, context="workflow output destination")
+                for source in _source_values(output_source, context=f"workflow output {destination_port}"):
+                    source_process, source_port = _source_endpoint(source, step_names)
+                    connections.append(NfConnection(source_process, source_port, None, destination_port))
+            case _:
+                raise ValueError(f"workflow output {raw_port!r} must define outputSource")
+    return connections
+
+
+def _connections(
+    workflow: Mapping[str, Any],
+    steps: list[Mapping[str, Any]],
+    processes: list[NfProcess],
+) -> list[NfConnection]:
+    step_names = _step_name_map(steps, processes)
+    return [
+        *_step_connections(steps, processes, step_names),
+        *_workflow_output_connections(workflow, step_names),
+    ]
+
+
+def _json_value(value: Any) -> Any:
+    match value:
+        case Mapping() as mapping:
+            return {str(key): _json_value(item) for key, item in mapping.items()}
+        case list() as items:
+            return [_json_value(item) for item in items]
+        case tuple() as items:
+            return [_json_value(item) for item in items]
+        case PathLike() as path:
+            return str(path)
+        case _:
+            return copy.deepcopy(value)
+
+
+def _compiled_workflow(rose_tree: RoseTree) -> tuple[NodeData, list[Any], Mapping[str, Any]]:
+    match rose_tree:
+        case RoseTree(data=NodeData() as node_data, sub_trees=sub_trees):
+            pass
+        case _:
+            raise TypeError("cwl_rosetree_to_nextflow requires a RoseTree[NodeData]")
+    match node_data.compiled_cwl:
+        case Mapping() as workflow if workflow.get("class") == "Workflow":
+            pass
+        case _:
+            raise ValueError("RoseTree root must contain a compiled CWL Workflow")
+    return node_data, sub_trees, workflow
+
+
+def _workflow_steps(workflow: Mapping[str, Any], *, child_count: int) -> list[Mapping[str, Any]]:
+    raw_steps = _as_list(workflow.get("steps", []), error="compiled CWL Workflow steps must be a list")
+    steps: list[Mapping[str, Any]] = []
+    for step in raw_steps:
+        match step:
+            case Mapping() as step_definition:
+                steps.append(step_definition)
+            case _:
+                raise ValueError("compiled CWL Workflow steps must be mappings")
+    if len(steps) != child_count:
+        raise ValueError("compiled CWL steps do not match RoseTree children")
+    return steps
+
+
+def _workflow_params(workflow: Mapping[str, Any], node_data: NodeData) -> dict[str, Any]:
+    workflow_inputs = _as_mapping(
+        workflow.get("inputs", {}),
+        error="compiled CWL Workflow inputs must be a mapping",
+    )
+    provided_params = _as_mapping(
+        node_data.workflow_inputs_file,
+        error="compiled workflow input values must be a mapping",
+    )
+    return {
+        _identifier(name, context="workflow input name"): _json_value(provided_params.get(name))
+        for name in workflow_inputs
+    }
+
+
+def cwl_rosetree_to_nextflow(rose_tree: RoseTree) -> NextflowWorkflow:
+    """Convert a compiled flat CWL RoseTree without invoking inference again."""
+    node_data, sub_trees, workflow = _compiled_workflow(rose_tree)
+    steps = _workflow_steps(workflow, child_count=len(sub_trees))
+    processes = [
+        _process(step, child)
+        for step, child in zip(steps, sub_trees, strict=True)
+    ]
+    return NextflowWorkflow(
+        name=_identifier(node_data.name, context="workflow name"),
+        processes=processes,
+        connections=_connections(workflow, list(steps), processes),
+        params=_workflow_params(workflow, node_data),
+    )

--- a/tests/test_nextflow_api.py
+++ b/tests/test_nextflow_api.py
@@ -1,0 +1,455 @@
+"""Sprint 1 acceptance tests for the Sophios Nextflow intermediate representation."""
+
+# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
+
+import copy
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from sophios import inference
+from sophios.api.python.workflow import CompiledWorkflow, Step, Workflow
+from sophios.nf_symbols import is_nextflow_identifier, normalize_nextflow_identifier
+from sophios.nf_types import NfConnection, NfPort, NfProcess, NextflowWorkflow
+from sophios.utils_nf import cwl_rosetree_to_nextflow, cwl_type_to_nf_qualifier
+from sophios.wic_types import GraphReps, NodeData, RoseTree, Tool, Yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _node_data(
+    name: str,
+    compiled_cwl: Yaml,
+    *,
+    workflow_inputs: Yaml | None = None,
+    source_yml: Yaml | None = None,
+) -> NodeData:
+    """Build the smallest real NodeData needed by a conversion fixture."""
+    return NodeData(
+        [],
+        name,
+        source_yml or {},
+        compiled_cwl,
+        Tool(f"{name}.cwl", compiled_cwl),
+        workflow_inputs or {},
+        {},
+        {},
+        cast(GraphReps, None),
+        {},
+        f'"{name}"',
+    )
+
+
+def _synthetic_rose(
+    workflow_cwl: Yaml,
+    tools: list[Yaml],
+    *,
+    workflow_inputs: Yaml | None = None,
+    source_yml: Yaml | None = None,
+) -> RoseTree:
+    """Construct a typed RoseTree without invoking compiler internals."""
+    children = [
+        RoseTree(_node_data(str(tool.get("id", f"tool_{index}")), tool), [])
+        for index, tool in enumerate(tools)
+    ]
+    return RoseTree(
+        _node_data(
+            str(workflow_cwl.get("id", "workflow")),
+            workflow_cwl,
+            workflow_inputs=workflow_inputs,
+            source_yml=source_yml,
+        ),
+        children,
+    )
+
+
+def _tool(
+    name: str,
+    *,
+    inputs: Yaml | None = None,
+    outputs: Yaml | None = None,
+    **extra: Any,
+) -> Yaml:
+    """Return a compact CommandLineTool dictionary."""
+    return {
+        "id": name,
+        "class": "CommandLineTool",
+        "cwlVersion": "v1.2",
+        "baseCommand": name,
+        "inputs": inputs or {},
+        "outputs": outputs or {},
+        **extra,
+    }
+
+
+def _workflow(steps: list[Yaml], *, inputs: Yaml | None = None, outputs: Yaml | None = None) -> Yaml:
+    """Return a compact compiled CWL Workflow dictionary."""
+    return {
+        "id": "wf",
+        "class": "Workflow",
+        "cwlVersion": "v1.2",
+        "inputs": inputs or {},
+        "outputs": outputs or {},
+        "steps": steps,
+    }
+
+
+@pytest.fixture(scope="module")
+def real_linear_rose() -> RoseTree:
+    """Compile a real three-process Python API workflow once for boundary tests."""
+    touch = Step(clt_path=REPO_ROOT / "cwl_adapters" / "touch.cwl")
+    touch.inputs.filename = "empty.txt"
+    append = Step(clt_path=REPO_ROOT / "cwl_adapters" / "append.cwl")
+    append.inputs.str = "Hello"
+    cat = Step(clt_path=REPO_ROOT / "cwl_adapters" / "cat.cwl")
+    return Workflow([touch, append, cat], "wf")._compile().rose
+
+
+# T1.1 — eight IR, validation, and hydration scenarios.
+
+
+@pytest.mark.fast
+def test_nf101_t11_port_dict_roundtrip() -> None:
+    port = NfPort(name="reads", qualifier="path", emit="staged")
+    assert NfPort.from_dict(port.to_dict()) == port
+
+
+@pytest.mark.fast
+def test_nf101_t11_process_dict_roundtrip() -> None:
+    process = NfProcess(
+        name="ALIGN",
+        inputs=[NfPort("reads", "path")],
+        outputs=[NfPort("bam", "path", "bam")],
+        script="align $reads",
+        container="aligner:1",
+        directives={"cpus": "2", "memory": "1024 MB"},
+    )
+    assert NfProcess.from_dict(process.to_dict()) == process
+
+
+@pytest.mark.fast
+def test_nf101_t11_workflow_dict_roundtrip() -> None:
+    workflow = NextflowWorkflow(
+        name="wf",
+        processes=[NfProcess("ECHO", [], [NfPort("out", "path", "out")], "echo hi")],
+        connections=[NfConnection("ECHO", "out", None, "result")],
+        params={"message": "hello"},
+    )
+    assert NextflowWorkflow.from_dict(workflow.to_dict()) == workflow
+
+
+@pytest.mark.fast
+def test_nf101_t11_json_roundtrip_is_deterministic() -> None:
+    workflow = NextflowWorkflow("wf", [], [], {"b": 2, "a": 1})
+    serialized = workflow.to_json()
+    assert serialized == workflow.to_json()
+    assert NextflowWorkflow.from_json(serialized) == workflow
+
+
+@pytest.mark.fast
+def test_nf101_t11_unparsed_content_survives_hydration() -> None:
+    workflow = NextflowWorkflow(
+        "wf",
+        [NfProcess("P", [], [], "true", directives={"_unparsed": "errorStrategy 'retry'"})],
+        [],
+        {},
+        directives={"_unparsed": "workflow.onComplete { ... }"},
+    )
+    hydrated = NextflowWorkflow.from_json(workflow.to_json())
+    assert hydrated.directives["_unparsed"] == "workflow.onComplete { ... }"
+    assert hydrated.processes[0].directives["_unparsed"] == "errorStrategy 'retry'"
+
+
+@pytest.mark.fast
+def test_nf101_t11_uses_nextflow_identifier_symbols() -> None:
+    for name in ("café", "Δelta", "$money", "_private", "Ⅻstep", "process"):
+        assert is_nextflow_identifier(name)
+        assert NfPort(name, "val").name == name
+
+    for name in ("if", "class", "_", "9start", "dash-name", "😀"):
+        assert not is_nextflow_identifier(name)
+        with pytest.raises(ValueError, match="Nextflow identifier"):
+            NfPort(name, "val")
+
+    assert normalize_nextflow_identifier("9-café") == "_9_café"
+    assert normalize_nextflow_identifier("if") == "_if"
+
+    with pytest.raises(ValueError, match="qualifier"):
+        NfPort("reads", "unsupported")
+
+
+@pytest.mark.fast
+def test_nf101_t11_rejects_duplicate_process_names() -> None:
+    process = NfProcess("P", [], [], "true")
+    with pytest.raises(ValueError, match="duplicate process"):
+        NextflowWorkflow("wf", [process, process], [], {})
+
+
+@pytest.mark.fast
+def test_nf101_t11_rejects_connection_to_unknown_process() -> None:
+    with pytest.raises(ValueError, match="unknown destination process"):
+        NextflowWorkflow("wf", [], [NfConnection(None, "message", "MISSING", "message")], {"message": "hi"})
+
+
+# T1.2 — five real-boundary and rejection scenarios.
+
+
+@pytest.mark.fast
+def test_nf101_t12_real_rosetree_converts(real_linear_rose: RoseTree) -> None:
+    converted = cwl_rosetree_to_nextflow(real_linear_rose)
+    assert converted.name == "wf"
+    assert [process.name for process in converted.processes] == [
+        "wf__step__1__touch",
+        "wf__step__2__append",
+        "wf__step__3__cat",
+    ]
+
+
+@pytest.mark.fast
+def test_nf101_t12_rejects_compiledworkflow_substitution() -> None:
+    compiled = CompiledWorkflow("wf", _workflow([]), {})
+    with pytest.raises(TypeError, match="RoseTree"):
+        cwl_rosetree_to_nextflow(cast(Any, compiled))
+
+
+@pytest.mark.fast
+def test_nf101_t12_requires_workflow_root() -> None:
+    rose = RoseTree(_node_data("tool", _tool("tool")), [])
+    with pytest.raises(ValueError, match="root.*Workflow"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_nf101_t12_rejects_nested_or_unsupported_workflow_constructs() -> None:
+    nested = _workflow([])
+    rose = _synthetic_rose(
+        _workflow([{"id": "nested", "in": {}, "out": [], "run": "nested.cwl"}]),
+        [nested],
+    )
+    with pytest.raises(ValueError, match="nested workflows.*Phase 2"):
+        cwl_rosetree_to_nextflow(rose)
+
+    conditional = _synthetic_rose(
+        _workflow([{"id": "conditional", "in": {}, "out": [], "run": "tool.cwl", "when": "$(true)"}]),
+        [_tool("tool")],
+    )
+    with pytest.raises(ValueError, match="when.*not supported.*Phase 1"):
+        cwl_rosetree_to_nextflow(conditional)
+
+
+@pytest.mark.fast
+def test_nf101_t12_conversion_does_not_mutate_rosetree(real_linear_rose: RoseTree) -> None:
+    before = copy.deepcopy(real_linear_rose.data.compiled_cwl)
+    cwl_rosetree_to_nextflow(real_linear_rose)
+    assert real_linear_rose.data.compiled_cwl == before
+
+
+# T1.3 — twelve type, command, container, and resource scenarios.
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("cwl_type", "qualifier"),
+    [
+        ("File", "path"),
+        ("Directory", "path"),
+        ("string", "val"),
+        ("int", "val"),
+        ("float", "val"),
+        ("boolean", "val"),
+        ("Any", "val"),
+        ({"type": "array", "items": "File"}, "path"),
+    ],
+    ids=["file", "directory", "string", "int", "float", "boolean", "any", "file-array"],
+)
+def test_nf101_t13_cwl_type_mapping(cwl_type: Any, qualifier: str) -> None:
+    assert cwl_type_to_nf_qualifier(cwl_type) == qualifier
+
+
+@pytest.mark.fast
+def test_nf101_t13_optional_input_maps_to_val_metadata() -> None:
+    tool = _tool("OPTIONAL", inputs={"message": {"type": ["null", "string"]}})
+    rose = _synthetic_rose(
+        _workflow(
+            [{"id": "OPTIONAL", "in": {"message": "message"}, "out": [], "run": "OPTIONAL.cwl"}],
+            inputs={"message": {"type": ["null", "string"]}},
+        ),
+        [tool],
+        workflow_inputs={"message": None},
+    )
+    process = cwl_rosetree_to_nextflow(rose).processes[0]
+    assert process.inputs[0].qualifier == "val"
+    assert process.directives["_optional_inputs"] == "message"
+
+
+@pytest.mark.fast
+def test_nf101_t13_composes_command_arguments_bindings_and_redirects() -> None:
+    tool = _tool(
+        "RUN",
+        inputs={
+            "message": {"type": "string", "inputBinding": {"position": 2, "prefix": "--message"}},
+            "source": {"type": "File"},
+        },
+        outputs={"report": {"type": "File", "outputBinding": {"glob": "stdout.txt"}}},
+        baseCommand=["python", "script.py"],
+        arguments=[{"position": 1, "prefix": "--mode", "valueFrom": "fast"}],
+        stdin="$(inputs.source.path)",
+        stdout="stdout.txt",
+        stderr="stderr.txt",
+    )
+    rose = _synthetic_rose(
+        _workflow(
+            [
+                {
+                    "id": "RUN",
+                    "in": {"message": "message", "source": "source"},
+                    "out": ["report"],
+                    "run": "RUN.cwl",
+                }
+            ],
+            inputs={"message": {"type": "string"}, "source": {"type": "File"}},
+            outputs={"report": {"type": "File", "outputSource": "RUN/report"}},
+        ),
+        [tool],
+        workflow_inputs={"message": "hello", "source": {"class": "File", "path": "input.txt"}},
+    )
+    process = cwl_rosetree_to_nextflow(rose).processes[0]
+    assert process.script == (
+        "python script.py --mode fast --message $message < $source > stdout.txt 2> stderr.txt"
+    )
+    assert process.directives["_output_glob.report"] == "stdout.txt"
+
+
+@pytest.mark.fast
+def test_nf101_t13_maps_docker_requirement() -> None:
+    tool = _tool(
+        "CONTAINER",
+        requirements={"DockerRequirement": {"dockerPull": "ubuntu:24.04"}},
+    )
+    rose = _synthetic_rose(
+        _workflow([{"id": "CONTAINER", "in": {}, "out": [], "run": "CONTAINER.cwl"}]),
+        [tool],
+    )
+    assert cwl_rosetree_to_nextflow(rose).processes[0].container == "ubuntu:24.04"
+
+
+@pytest.mark.fast
+def test_nf101_t13_maps_cpu_and_memory_requirements() -> None:
+    tool = _tool(
+        "RESOURCES",
+        requirements={"ResourceRequirement": {"coresMin": 2, "ramMin": 1024}},
+    )
+    rose = _synthetic_rose(
+        _workflow([{"id": "RESOURCES", "in": {}, "out": [], "run": "RESOURCES.cwl"}]),
+        [tool],
+    )
+    assert cwl_rosetree_to_nextflow(rose).processes[0].directives == {
+        "cpus": "2",
+        "memory": "1024 MB",
+    }
+
+
+# T1.4 — eight graph, interface, params, scatter, and inference scenarios.
+
+
+@pytest.mark.fast
+def test_nf101_t14_preserves_linear_dag(real_linear_rose: RoseTree) -> None:
+    workflow = cwl_rosetree_to_nextflow(real_linear_rose)
+    internal = [connection for connection in workflow.connections if connection.from_process is not None
+                and connection.to_process is not None]
+    assert [(edge.from_process, edge.from_port, edge.to_process, edge.to_port) for edge in internal] == [
+        ("wf__step__1__touch", "file", "wf__step__2__append", "file"),
+        ("wf__step__2__append", "file", "wf__step__3__cat", "file"),
+    ]
+
+
+@pytest.mark.fast
+def test_nf101_t14_preserves_fanout() -> None:
+    producer = _tool("A", outputs={"out": {"type": "File"}})
+    consumer_b = _tool("B", inputs={"value": {"type": "File"}})
+    consumer_c = _tool("C", inputs={"value": {"type": "File"}})
+    rose = _synthetic_rose(
+        _workflow(
+            [
+                {"id": "A", "in": {}, "out": ["out"], "run": "A.cwl"},
+                {"id": "B", "in": {"value": "A/out"}, "out": [], "run": "B.cwl"},
+                {"id": "C", "in": {"value": "A/out"}, "out": [], "run": "C.cwl"},
+            ]
+        ),
+        [producer, consumer_b, consumer_c],
+    )
+    connections = cwl_rosetree_to_nextflow(rose).connections
+    assert len([edge for edge in connections if edge.from_process == "A" and edge.from_port == "out"]) == 2
+
+
+@pytest.mark.fast
+def test_nf101_t14_preserves_workflow_input_connection(real_linear_rose: RoseTree) -> None:
+    connections = cwl_rosetree_to_nextflow(real_linear_rose).connections
+    assert NfConnection(None, "wf__step__1__touch___filename", "wf__step__1__touch", "filename") in connections
+
+
+@pytest.mark.fast
+def test_nf101_t14_preserves_workflow_output_connection(real_linear_rose: RoseTree) -> None:
+    connections = cwl_rosetree_to_nextflow(real_linear_rose).connections
+    assert NfConnection(
+        "wf__step__3__cat",
+        "output",
+        None,
+        "wf__step__3__cat___output",
+    ) in connections
+
+
+@pytest.mark.fast
+def test_nf101_t14_copies_workflow_params(real_linear_rose: RoseTree) -> None:
+    params = cwl_rosetree_to_nextflow(real_linear_rose).params
+    assert params == {
+        "wf__step__1__touch___filename": "empty.txt",
+        "wf__step__2__append___str": "Hello",
+    }
+
+
+@pytest.mark.fast
+def test_nf101_t14_scatter_is_metadata_only() -> None:
+    tool = _tool("SCATTER", inputs={"item": {"type": "string"}})
+    step = {
+        "id": "SCATTER",
+        "in": {"item": "items"},
+        "out": [],
+        "run": "SCATTER.cwl",
+        "scatter": "item",
+        "scatterMethod": "dotproduct",
+    }
+    rose = _synthetic_rose(
+        _workflow([step], inputs={"items": {"type": {"type": "array", "items": "string"}}}),
+        [tool],
+        workflow_inputs={"items": ["a", "b"]},
+    )
+    process = cwl_rosetree_to_nextflow(rose).processes[0]
+    assert process.directives["_scatter"] == "true"
+    assert process.directives["_scatter_inputs"] == "item"
+    assert process.directives["_scatter_method"] == "dotproduct"
+
+
+@pytest.mark.fast
+def test_nf101_t14_forward_conversion_does_not_call_inference(
+    monkeypatch: pytest.MonkeyPatch,
+    real_linear_rose: RoseTree,
+) -> None:
+    def fail_if_called(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("forward conversion must not invoke inference")
+
+    monkeypatch.setattr(inference, "perform_edge_inference", fail_if_called)
+    cwl_rosetree_to_nextflow(real_linear_rose)
+
+
+@pytest.mark.fast
+def test_nf101_t14_rejects_unknown_connection_source() -> None:
+    tool = _tool("B", inputs={"value": {"type": "File"}})
+    rose = _synthetic_rose(
+        _workflow([{"id": "B", "in": {"value": "MISSING/out"}, "out": [], "run": "B.cwl"}]),
+        [tool],
+    )
+    with pytest.raises(ValueError, match="unknown source process"):
+        cwl_rosetree_to_nextflow(rose)


### PR DESCRIPTION
Implements Phase 1 Sprint 1 by converting the existing compiled `RoseTree` into validated, JSON-serializable Nextflow IR. Covers process semantics, resources, workflow I/O, DAG/fan-out wiring, and scatter metadata without rerunning inference or modifying the Sophios compiler. Identifier handling follows the pinned Nextflow 26.04.2 grammar rather than an ad hoc regex.

Adds 33 TDD scenarios covering IR validation, hydration, real RoseTree conversion, process mapping, and topology. Verified on Python 3.11 and 3.12 with 33/33 Sprint 1 scenarios, 108 fast tests, 60 API/tool-builder regressions, static checks, codespell, and representative Nextflow v2 parser checks passing.