### PR TITLE
fix(docker): correct stale REST entry point module path

### DIFF
--- a/docker/Dockerfile_ubuntu_REST
+++ b/docker/Dockerfile_ubuntu_REST
@@ -1,19 +1,29 @@
-FROM ubuntu:jammy
+# Sophios REST API image.
+#
+# NOTE: noble (24.04) ships Python 3.12. jammy (22.04) ships 3.10, which is
+# below the >=3.11 that pyproject.toml requires, so the install cannot succeed
+# there.
+FROM ubuntu:noble
 
-RUN apt update && \
-    apt install software-properties-common -y && \
-    apt install curl -y && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py && \
-    apt autoremove -y && \
+# python3-pip comes from the distro, so no separate bootstrap host is needed.
+# graphviz supplies the `dot` binary that the graphviz Python bindings shell
+# out to; the bindings alone are not enough.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        python3 \
+        python3-pip \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /sophios
 WORKDIR /sophios
 
-RUN pip3 install /sophios --no-cache-dir
+# PEP 668 marks the distro interpreter externally managed. Inside a container
+# there is no other consumer of site-packages, so installing into it directly
+# is what we want.
+RUN pip3 install --no-cache-dir --break-system-packages /sophios
 
 # Then run the sophios REST API through port 3000
 EXPOSE 3000
 
-CMD ["uvicorn", "sophios.api.http.restapi:app", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["uvicorn", "sophios.api.rest.api:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "3000:3000"
     environment:
       - PATH=$PATH
-    command: ["uvicorn", "sophios.api.http.restapi:app", "--host", "0.0.0.0", "--port", "3000"]
+    command: ["uvicorn", "sophios.api.rest.api:app", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
Commit 1fafbaa ('necessary name change and reorg of Sophios APIs') removed src/sophios/api/http/restapi.py, but the container entry points still name it. Both the REST image and docker-compose therefore reference a module that does not exist, so the published REST container cannot start.

Point both at the real module, sophios.api.rest.api:app, verified to import and expose a FastAPI app.