### PR TITLE
Spec 1: a specified .wic syntax layer, and one language across both front-ends

### DIFF
--- a/design_docs/core-refactor-design.md
+++ b/design_docs/core-refactor-design.md
@@ -4,6 +4,19 @@
 **Baseline:** `master` at `6570369`
 **Scope:** Four specs, delivered in order. Each is independently shippable.
 
+## Naming
+
+**Sophios** is the language. It has one DSL with two surfaces: a YAML spelling,
+conventionally stored in files named `.wic`, and the Python API. Neither is
+primary; §5.3 and Spec 1's adherence properties depend on that being true.
+
+`.wic` is a file extension. This document writes "`.wic` files" for files on
+disk and "Sophios" for the language. Some concrete syntax still carries the
+older `wic` prefix — the `wic:` block, the `!ii` / `!&` / `!*` tags, the `wic_*`
+desugared keys — and keeps it, because existing workflows depend on those
+spellings. The language's own version tag is `lang_version`, which is
+unimplemented and therefore free to name correctly.
+
 ---
 
 ## 1. Governing constraint
@@ -61,8 +74,9 @@ precedes Spec 3.
 
 ### Guaranteed
 
-- The `.wic` DSL. `wic_version` 0.0.1 is defined to accept what exists today,
-  validated against `docs/tutorials/`, `examples/`, and the `.wic` files in
+- The Sophios DSL, in both surfaces. `lang_version` 0.0.1 is defined to accept
+  what exists today, validated against `docs/tutorials/`, `examples/`, and the
+  `.wic` files in
   `mm-workflows` and `image-workflows`. The version tag is optional, so no
   existing file requires editing.
 - `Workflow`, `Step`, `CompiledWorkflow`, and the `tool_builder` classes.
@@ -162,11 +176,11 @@ constraint.
 
 ---
 
-## 5. Spec 1 — Specified and versioned `.wic` grammar
+## 5. Spec 1 — Specified and versioned Sophios grammar
 
 ### 5.1 What is being specified
 
-`.wic` is a leaky abstraction over CWL, deliberately. A user writes shorthand
+Sophios is a leaky abstraction over CWL, deliberately. A user writes shorthand
 for the common case and drops into raw CWL for anything the shorthand does not
 cover. That design is retained. Sealing the abstraction would mean re-inventing
 CWL one feature at a time.
@@ -180,14 +194,14 @@ The grammar pins the leak. It does not plug it.
 
 ### 5.2 The CWL substrate
 
-Passthrough means "this is CWL, handed over unchanged", so part of `.wic`'s
+Passthrough means "this is CWL, handed over unchanged", so part of Sophios's
 meaning is CWL's meaning. A specification written against an unspecified CWL
 version specifies nothing. At baseline the version is genuinely unspecified:
 `compiler.py` emits `v1.2` for workflows, `python_cwl_adapter.py` hardcodes
 `v1.0` for generated CommandLineTools, and the schema validates `cwlVersion` as
 any non-empty string.
 
-**`.wic` is specified as an abstraction over CWL v1.2** — one declared version,
+**Sophios is specified as an abstraction over CWL v1.2** — one declared version,
 enforced as an enum rather than a free string, applied consistently across every
 emitting path. This gives passthrough a precise meaning and makes the residue
 property checkable.
@@ -204,13 +218,13 @@ Three concerns, currently fused into one generated JSON Schema:
 
 | Layer | Question | Environment-dependent | Artifact |
 |---|---|---|---|
-| **Syntax** | Is this well-formed `.wic`? | No — this is specified | Typed AST + parser with source positions |
+| **Syntax** | Is this well-formed Sophios? | No — this is specified | Typed AST + parser with source positions |
 | **Resolution** | Do referenced steps exist here? | Yes | Resolution pass, "unknown tool" diagnostics |
 | **Type checking** | Do port types line up? | Yes | Type pass |
 
 Fusing them is why the schema is enormous, slow, unstable across environments,
 and reports `None is not of type 'object'` instead of naming a file and line.
-At baseline, `.wic` validity depends on which plugins are installed, because the
+At baseline, Sophios validity depends on which plugins are installed, because the
 schema enumerates every installed tool as a valid step name. That also makes the
 existing fuzzer unusable as an oracle: it samples a random subset of an
 environment-dependent schema.
@@ -223,9 +237,9 @@ editor support, so there is one source of truth.
 
 ### 5.4 The leak boundary
 
-`.wic` leaks three ways:
+Sophios leaks three ways:
 
-1. **wic-owned syntax**, consumed and stripped before emitting CWL: `!&`, `!*`,
+1. **Sophios-owned syntax**, consumed and stripped before emitting CWL: `!&`, `!*`,
    `!ii`, and the `wic:` sidecar.
 2. **Interpreted CWL**, read and acted upon: `scatter` and `when` inject
    `ScatterFeatureRequirement` / `InlineJavascriptRequirement`; an inline `run:`
@@ -234,7 +248,7 @@ editor support, so there is one source of truth.
    `requirements` / `hints`.
 
 **The interpreted set (2) is enumerated exhaustively. Everything else is
-passthrough by definition, and the residue after stripping wic-owned syntax
+passthrough by definition, and the residue after stripping Sophios-owned syntax
 must be a valid CWL v1.2 document.** This yields two directly testable
 properties and keeps existing files working.
 
@@ -297,14 +311,14 @@ conformance corpus with the exclusion documented.
 The language is specified and versioned, not frozen. Pinning without an
 evolution path only defers the problem.
 
-- **`wic_version` starts at 0.0.1**, defined against CWL v1.2. The `.wic`
+- **`lang_version` starts at 0.0.1**, defined against CWL v1.2. The Sophios
   version and its CWL substrate move together.
 - **The tag is optional and expected to stay unused.** Downstream files are
   tagless.
 - **Versioning is semantic and applied by human judgment**, not derived from
   diffs.
 
-**Resolution.** An untagged file compiles at the **highest `wic_version` under
+**Resolution.** An untagged file compiles at the **highest `lang_version` under
 which that source actually compiles** — not the highest version shipped:
 
 | Case | Resolution |
@@ -338,8 +352,8 @@ hard.
 | Python API | An attribute on `CompiledWorkflow` |
 | Emitted artifact | A namespaced annotation, declared in `$namespaces` so output remains valid CWL v1.2 |
 
-**The version is settable without editing anything** — a `--wic_version` CLI
-flag and a matching `wic_version: str | None = None` parameter on the Python API
+**The version is settable without editing anything** — a `--lang_version` CLI
+flag and a matching `lang_version: str | None = None` parameter on the Python API
 compile and run entry points. This reaches legacy `.wic` files and deeply nested
 `Workflow` objects without touching either.
 
@@ -444,7 +458,7 @@ implicit in dictionary manipulation and call-stack state.
 
 | Phase | Transform | Environment-dependent |
 |---|---|---|
-| Parse | `.wic` → AST | No |
+| Parse | Sophios source → AST | No |
 | Resolve | AST + registry → resolved AST | Yes |
 | Lower | resolved AST → `WorkflowGraph` | No |
 | Link | compose subgraphs; namespacing; LCA explicit edges; obligations | No |
@@ -490,7 +504,7 @@ is not the justification for this work.
 | Grammar before IR | IR first, grammar as documentation | The oracle needs a fixed vocabulary to state properties in. IR first means refactoring with no stable target. |
 | Property tests before IR | Refactor first, test after | Without an oracle a rewrite is unverifiable. Differential testing is what makes Spec 3 verified rather than hopeful. |
 | Verification is property-based | More example tests | Example tests find breakage someone already thought to write down. That is the blind spot being removed. |
-| `wic_version` 0.0.1 on CWL v1.2 | Leave the version unspecified; target a later revision | Passthrough makes part of our meaning CWL's meaning, so an unspecified version specifies nothing. v1.2 is released and already emitted. |
+| `lang_version` 0.0.1 on CWL v1.2 | Leave the version unspecified; target a later revision | Passthrough makes part of our meaning CWL's meaning, so an unspecified version specifies nothing. v1.2 is released and already emitted. |
 | Version inferred as highest under which the source compiles | Highest shipped version; require the tag; default to 0.0.1 | "Highest shipped" silently reinterprets files a later version changed. Inference from what compiles is self-correcting and keeps downstream tagless. |
 | Version setting global to the compilation | Per-file or per-`Workflow` override | A mixed-version tree makes meaning depend on file location and lets an edge join ports under different language rules. Unrepresentable is better than discouraged. |
 | Typed AST via stdlib `dataclasses` | pydantic | Pydantic coerces by default; a frontend needs exact, position-aware rejection. It would also define the language in terms of a third party's validation semantics. |

--- a/design_docs/core-refactor-design.md
+++ b/design_docs/core-refactor-design.md
@@ -76,9 +76,8 @@ precedes Spec 3.
 
 - The Sophios DSL, in both surfaces. `lang_version` 0.0.1 is defined to accept
   what exists today, validated against `docs/tutorials/`, `examples/`, and the
-  `.wic` files in
-  `mm-workflows` and `image-workflows`. The version tag is optional, so no
-  existing file requires editing.
+  `.wic` files in `mm-workflows` and `image-workflows`. The version tag is
+  optional, so no existing file requires editing.
 - `Workflow`, `Step`, `CompiledWorkflow`, and the `tool_builder` classes.
 - The five types reachable by external callers: `Tools`, `StepId`, `Tool`,
   `Json`, `RawJson`.
@@ -240,7 +239,8 @@ editor support, so there is one source of truth.
 Sophios leaks three ways:
 
 1. **Sophios-owned syntax**, consumed and stripped before emitting CWL: `!&`, `!*`,
-   `!ii`, and the `wic:` sidecar.
+   `!ii`, `!cwl` (the tag is consumed; its expression is handed to CWL
+   unresolved), and the `wic:` sidecar.
 2. **Interpreted CWL**, read and acted upon: `scatter` and `when` inject
    `ScatterFeatureRequirement` / `InlineJavascriptRequirement`; an inline `run:`
    registers a tool.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ understand, debug, and review.
    :caption: Advanced YAML and Operations
 
    advanced.md
-   wic_language_reference.md
+   sophios_language_reference.md
    tutorials/tutorials.rst
    validation.md
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ understand, debug, and review.
    :caption: Advanced YAML and Operations
 
    advanced.md
+   wic_language_reference.md
    tutorials/tutorials.rst
    validation.md
 

--- a/docs/pdf_index.rst
+++ b/docs/pdf_index.rst
@@ -17,7 +17,7 @@ User Documentation
    ichnaea_compact_compute.md
    python_api_reference.rst
    advanced.md
-   wic_language_reference.md
+   sophios_language_reference.md
    tutorials/tutorials.rst
    validation.md
 

--- a/docs/pdf_index.rst
+++ b/docs/pdf_index.rst
@@ -17,6 +17,7 @@ User Documentation
    ichnaea_compact_compute.md
    python_api_reference.rst
    advanced.md
+   wic_language_reference.md
    tutorials/tutorials.rst
    validation.md
 

--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -168,6 +168,15 @@ A tag outside the four above (`!foo`) is an error, not a fifth-and-a-half
 form. The loader has always rejected such documents, and the syntax layer
 must never accept more than the language it specifies.
 
+An **untagged mapping or sequence** in input position is an inline literal —
+the same as writing `!ii` — because a collection cannot name a workflow input,
+so a literal is its only possible meaning. The tag is still the recommended
+spelling: it states the intent instead of leaving it to be inferred.
+
+A tag outside the four above (`!foo`) is an error, not a fifth-and-a-half
+form. The loader has always rejected such documents, and the syntax layer
+must never accept more than the language it specifies.
+
 ### 4.2 Interpreted CWL keys
 
 The complete set Sophios reads and acts upon:

--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -159,6 +159,15 @@ in:
     pdb_code: 1aki
 ```
 
+An **untagged mapping or sequence** in input position is an inline literal —
+the same as writing `!ii` — because a collection cannot name a workflow input,
+so a literal is its only possible meaning. The tag is still the recommended
+spelling: it states the intent instead of leaving it to be inferred.
+
+A tag outside the four above (`!foo`) is an error, not a fifth-and-a-half
+form. The loader has always rejected such documents, and the syntax layer
+must never accept more than the language it specifies.
+
 ### 4.2 Interpreted CWL keys
 
 The complete set Sophios reads and acts upon:

--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -1,21 +1,37 @@
-# The `.wic` Language Reference
+# The Sophios Language Reference
 
-**Version:** `wic_version` 0.0.1
+**Version:** `lang_version` 0.0.1
 **Substrate:** CWL v1.2
 
-This is the human-readable definition of the Sophios workflow language. The
-executable definition is `sophios.lang` — the typed AST and parser — and the
-two are meant to agree. Where they disagree, that is a bug in one of them.
+This is the human-readable definition of **Sophios**, the workflow language.
+The executable definition is `sophios.lang` — the typed AST and parser — and
+the two are meant to agree. Where they disagree, that is a bug in one of them.
 
-Sophios has **two front-ends that produce the same language**: `.wic` files
-written by hand, and the Python API. Both are defined by this document, and
-§6 states what each is obliged to do.
+## The language and its two surfaces
+
+Sophios is the language. It has one DSL, and that DSL can be written two ways:
+
+| Surface | How it is written | Where it lives |
+|---|---|---|
+| **YAML** | The YAML-based spelling of the DSL | Conventionally in files named `.wic` |
+| **Python API** | `Workflow`, `Step`, `CommandLineTool` | Python source |
+
+Neither is "the language" and neither is subordinate to the other. They are two
+ways of saying the same thing, which is why §6 can state what each owes the
+other and check it.
+
+`.wic` is **a file extension, not a language**. This document says "`.wic`
+files" when it means files on disk, and "Sophios" when it means the language.
+A handful of spellings inside the syntax still carry the older `wic` prefix —
+the `wic:` block, the `!ii` / `!&` / `!*` tags, and the `wic_*` desugared keys.
+Those are concrete syntax that existing workflows depend on, so they stay as
+they are; they are not evidence that the language is called wic.
 
 ---
 
 ## 1. What kind of language this is
 
-`.wic` is a **leaky abstraction over CWL, deliberately**. You write shorthand
+Sophios is a **leaky abstraction over CWL, deliberately**. You write shorthand
 for the common case and drop into raw CWL for anything the shorthand does not
 cover. Sealing the abstraction would mean re-inventing CWL one feature at a
 time and asking users to wait.
@@ -25,7 +41,7 @@ point of this document:
 
 | Category | What Sophios does | Examples |
 |---|---|---|
-| **wic-owned** | Consumes it; never appears in the output | `!ii`, `!&`, `!*`, `!cwl`, the `wic:` block |
+| **Sophios-owned** | Consumes it; never appears in the output | `!ii`, `!&`, `!*`, `!cwl`, the `wic:` block |
 | **Interpreted CWL** | Reads it *and acts on it* | `scatter`, `scatterMethod`, `when`, inline `run` |
 | **Passthrough CWL** | Copies it out unchanged | `$namespaces`, `$schemas`, `requirements`, `hints`, everything else |
 
@@ -37,7 +53,7 @@ rather than a surprise.
 
 ## 2. Document structure
 
-A `.wic` document is a YAML mapping. Every key is optional.
+In its YAML surface, a Sophios document is a YAML mapping. Every key is optional.
 
 ```yaml
 wic:            # optional  — compiler metadata, never emitted to CWL
@@ -179,14 +195,14 @@ A bare `wic:` with nothing under it is an empty block, not an error.
 
 ---
 
-## 6. How the two front-ends adhere
+## 6. How the two surfaces adhere
 
 This is the part that keeps the language single.
 
-### 6.1 Two surface forms per construct
+### 6.1 Two spellings per construct
 
-Every wic-owned construct has a **tagged** form and a **desugared** form, and
-they are equivalent:
+Within the YAML surface, every Sophios-owned construct has a **tagged** form
+and a **desugared** form, and they are equivalent:
 
 | Construct | Tagged | Desugared |
 |---|---|---|
@@ -202,12 +218,12 @@ desugared spelling.
 
 **Write the tagged form.** The desugared form is what tooling emits.
 
-### 6.2 What each front-end must do
+### 6.2 What each surface must do
 
-**`.wic` files** are the language as written. They are parsed by
+**`.wic` files** are the YAML surface as written. They are parsed by
 `sophios.lang.parse`, which accepts both spellings above.
 
-**The Python API** (`Workflow`, `Step`) is a second front-end over the same
+**The Python API** (`Workflow`, `Step`) is the second surface of the same
 language. `Workflow.write_wic()` and `.to_wic_yaml()` emit `.wic` documents,
 using the desugared spelling and sequence-form steps with explicit `id:`.
 
@@ -224,7 +240,7 @@ example — see `tests/core/test_lang_parser.py`.
 
 ### 6.3 What this does *not* cover
 
-This document defines **syntax**: whether a document is well-formed. Two
+This document defines **syntax**: whether a Sophios document is well-formed. Two
 further questions are deliberately separate because they depend on the
 environment, not the language:
 
@@ -238,11 +254,11 @@ without the right plugins installed. That is not a language error.
 
 ## 7. Versioning
 
-`wic_version` starts at **0.0.1**, defined against CWL v1.2. The `.wic` version
-and its CWL substrate move together.
+`lang_version` starts at **0.0.1**, defined against CWL v1.2. The Sophios
+version and its CWL substrate move together.
 
 The version tag is **optional and expected to stay unused**. An untagged file
-is compiled at the highest `wic_version` under which that source actually
+is compiled at the highest `lang_version` under which that source actually
 compiles — not merely the newest version available. That means:
 
 - A file using only long-standing syntax resolves to the newest version.

--- a/docs/wic_language_reference.md
+++ b/docs/wic_language_reference.md
@@ -1,0 +1,259 @@
+# The `.wic` Language Reference
+
+**Version:** `wic_version` 0.0.1
+**Substrate:** CWL v1.2
+
+This is the human-readable definition of the Sophios workflow language. The
+executable definition is `sophios.lang` — the typed AST and parser — and the
+two are meant to agree. Where they disagree, that is a bug in one of them.
+
+Sophios has **two front-ends that produce the same language**: `.wic` files
+written by hand, and the Python API. Both are defined by this document, and
+§6 states what each is obliged to do.
+
+---
+
+## 1. What kind of language this is
+
+`.wic` is a **leaky abstraction over CWL, deliberately**. You write shorthand
+for the common case and drop into raw CWL for anything the shorthand does not
+cover. Sealing the abstraction would mean re-inventing CWL one feature at a
+time and asking users to wait.
+
+The abstraction leaks in three ways, and knowing which is which is the whole
+point of this document:
+
+| Category | What Sophios does | Examples |
+|---|---|---|
+| **wic-owned** | Consumes it; never appears in the output | `!ii`, `!&`, `!*`, `!cwl`, the `wic:` block |
+| **Interpreted CWL** | Reads it *and acts on it* | `scatter`, `scatterMethod`, `when`, inline `run` |
+| **Passthrough CWL** | Copies it out unchanged | `$namespaces`, `$schemas`, `requirements`, `hints`, everything else |
+
+The interpreted set is closed and listed in §4.2. **Anything not in it is
+passthrough, by definition.** That rule is what makes the leak a contract
+rather than a surprise.
+
+---
+
+## 2. Document structure
+
+A `.wic` document is a YAML mapping. Every key is optional.
+
+```yaml
+wic:            # optional  — compiler metadata, never emitted to CWL
+steps:          # the workflow's steps
+inputs:         # CWL workflow inputs        (passthrough)
+outputs:        # CWL workflow outputs       (passthrough)
+$namespaces:    # any other CWL key          (passthrough)
+```
+
+An empty document is well-formed and carries nothing.
+
+---
+
+## 3. Steps
+
+### 3.1 Three surface forms
+
+All three are long-standing, all remain supported, and **all produce the same
+result**. Use whichever reads better.
+
+**Mapping, keyed by step name** — cannot repeat a step name:
+
+```yaml
+steps:
+  touch:
+    in:
+      filename: !ii empty.txt
+```
+
+**Sequence with `id:`** — required when the same tool appears twice:
+
+```yaml
+steps:
+- id: append
+  in: {str: !ii Hello}
+- id: append
+  in: {str: !ii World}
+```
+
+**Sequence of single-key mappings** — the key is the step name:
+
+```yaml
+steps:
+- touch:
+    in:
+      filename: !ii empty.txt
+```
+
+A step may have no body at all:
+
+```yaml
+steps:
+  some_subworkflow.wic:
+```
+
+### 3.2 Step keys
+
+| Key | Meaning |
+|---|---|
+| `in` | Input bindings (§4) |
+| `out` | Output bindings (§3.3) |
+| `scatter`, `scatterMethod` | Interpreted: Sophios adds `ScatterFeatureRequirement` |
+| `when` | Interpreted: Sophios adds `InlineJavascriptRequirement` |
+| `run` | Interpreted: an inline CWL tool definition |
+| *anything else* | Passthrough |
+
+### 3.3 Outputs
+
+`out:` is a sequence. An entry is either a bare name, or a name bound to an
+edge definition:
+
+```yaml
+out:
+- file                    # just names the output
+- file: !& file_touch     # names it and defines an edge
+```
+
+---
+
+## 4. Input values
+
+### 4.1 The five forms
+
+A step input is exactly one of these. There is no sixth form.
+
+| Form | Written | Means |
+|---|---|---|
+| Inline literal | `f: !ii empty.txt` | A literal value. Never an edge. |
+| Edge definition | `f: !& name` | Defines an explicit edge at this point |
+| Edge reference | `f: !* name` | Consumes an edge defined elsewhere |
+| Raw CWL reference | `f: !cwl step/out` | Opaque to Sophios; passed through unresolved |
+| Unresolved name | `f: some_input` | Must resolve to a workflow input |
+
+An untagged bare string is an **unresolved name**. If it does not name a
+workflow input, you get a diagnostic telling you which of the two remedies you
+probably meant — `!ii` for a literal, `!cwl` for a CWL reference.
+
+`!ii` accepts any YAML value, not just scalars:
+
+```yaml
+in:
+  config: !ii
+    pdb_code: 1aki
+```
+
+### 4.2 Interpreted CWL keys
+
+The complete set Sophios reads and acts upon:
+
+```
+scatter    scatterMethod    when    run
+```
+
+Everything else on a step is passthrough.
+
+---
+
+## 5. The `wic:` block
+
+Compiler metadata. Never emitted to CWL.
+
+```yaml
+wic:
+  graphviz:
+    label: Protein-ligand docking
+  default_implementation: gromacs
+  steps:
+    (1, extract):
+      wic:
+        graphviz:
+          label: extract structures
+```
+
+Step keys inside `wic: steps:` have the form `(index, name)` — the index is
+1-based and matches the step's position. Sophios parses these into a structured
+key; you should never have to parse that string yourself.
+
+A bare `wic:` with nothing under it is an empty block, not an error.
+
+---
+
+## 6. How the two front-ends adhere
+
+This is the part that keeps the language single.
+
+### 6.1 Two surface forms per construct
+
+Every wic-owned construct has a **tagged** form and a **desugared** form, and
+they are equivalent:
+
+| Construct | Tagged | Desugared |
+|---|---|---|
+| Inline literal | `!ii value` | `{wic_inline_input: value}` |
+| Edge definition | `!& name` | `{wic_anchor: name}` |
+| Edge reference | `!* name` | `{wic_alias: name}` |
+| Raw CWL reference | `!cwl expr` | `{wic_raw_cwl: expr}` |
+
+The desugared form exists for a specific reason: a YAML constructor that
+re-emitted its own tag would fire again when the document is reloaded, so the
+loader would not be idempotent. Machine-generated documents therefore use the
+desugared spelling.
+
+**Write the tagged form.** The desugared form is what tooling emits.
+
+### 6.2 What each front-end must do
+
+**`.wic` files** are the language as written. They are parsed by
+`sophios.lang.parse`, which accepts both spellings above.
+
+**The Python API** (`Workflow`, `Step`) is a second front-end over the same
+language. `Workflow.write_wic()` and `.to_wic_yaml()` emit `.wic` documents,
+using the desugared spelling and sequence-form steps with explicit `id:`.
+
+Two obligations follow, and both are enforced by tests rather than convention:
+
+1. **Whatever the Python API emits must parse.** An API that produced
+   documents its own parser rejects would mean two languages wearing one name.
+2. **Both spellings must produce the same result.** `!ii x` and
+   `{wic_inline_input: x}` are the same input, so compiling either must give
+   the same answer.
+
+The second obligation is checked as a property over generated inputs, not by
+example — see `tests/core/test_lang_parser.py`.
+
+### 6.3 What this does *not* cover
+
+This document defines **syntax**: whether a document is well-formed. Two
+further questions are deliberately separate because they depend on the
+environment, not the language:
+
+- **Resolution** — do the step names refer to tools that exist *here*?
+- **Type checking** — do the connected ports have compatible types?
+
+A document can be perfectly well-formed and still fail to resolve on a machine
+without the right plugins installed. That is not a language error.
+
+---
+
+## 7. Versioning
+
+`wic_version` starts at **0.0.1**, defined against CWL v1.2. The `.wic` version
+and its CWL substrate move together.
+
+The version tag is **optional and expected to stay unused**. An untagged file
+is compiled at the highest `wic_version` under which that source actually
+compiles — not merely the newest version available. That means:
+
+- A file using only long-standing syntax resolves to the newest version.
+- A file using syntax a later version dropped resolves to the newest version
+  that still accepts it, and keeps working.
+- A file using syntax only a newer version added resolves there automatically,
+  with no tag required to adopt a feature.
+
+You need a tag only to pin a file for reproducibility, or where a construct is
+valid under two versions with different meanings.
+
+The version Sophios actually chose is always reported — on the command line, on
+`CompiledWorkflow`, and as an annotation in the emitted CWL. You should never
+have to guess which language your file was read as.

--- a/src/sophios/lang/__init__.py
+++ b/src/sophios/lang/__init__.py
@@ -1,7 +1,7 @@
-"""The `.wic` language layer: typed AST, parser, and diagnostics.
+"""The Sophios language layer: typed AST, parser, and diagnostics.
 
 This package is the syntax layer of the specification — it answers "is this a
-well-formed `.wic` document?" without consulting which tools happen to be
+well-formed Sophios document?" without consulting which tools happen to be
 installed. Name resolution and type checking are separate, environment-
 dependent concerns.
 

--- a/src/sophios/lang/__init__.py
+++ b/src/sophios/lang/__init__.py
@@ -1,0 +1,50 @@
+"""The `.wic` language layer: typed AST, parser, and diagnostics.
+
+This package is the syntax layer of the specification — it answers "is this a
+well-formed `.wic` document?" without consulting which tools happen to be
+installed. Name resolution and type checking are separate, environment-
+dependent concerns.
+
+See design_docs/core-refactor-design.md, Spec 1.
+"""
+from .diagnostics import Code, Diagnostic, Diagnostics, Severity
+from .nodes import (
+    Document,
+    EdgeDef,
+    EdgeRef,
+    InlineLiteral,
+    InputValue,
+    OpaqueCwl,
+    OutputBinding,
+    RawCwlRef,
+    Step,
+    StepKey,
+    UnresolvedName,
+    WicSidecar,
+)
+from .parser import INTERPRETED_STEP_KEYS, TAG_RAW_CWL, ParseResult, parse
+from .spans import SourceSpan
+
+__all__ = [
+    'INTERPRETED_STEP_KEYS',
+    'TAG_RAW_CWL',
+    'Code',
+    'Diagnostic',
+    'Diagnostics',
+    'Document',
+    'EdgeDef',
+    'EdgeRef',
+    'InlineLiteral',
+    'InputValue',
+    'OpaqueCwl',
+    'OutputBinding',
+    'ParseResult',
+    'RawCwlRef',
+    'Severity',
+    'SourceSpan',
+    'Step',
+    'StepKey',
+    'UnresolvedName',
+    'WicSidecar',
+    'parse',
+]

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -5,9 +5,9 @@ what to do with them and a malformed document can yield several errors in one
 pass instead of one per run. See design_docs/core-refactor-design.md, Spec 1.
 """
 from collections.abc import Iterable, Iterator, Sequence
-from typing import overload
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import overload
 
 from .spans import SourceSpan
 
@@ -35,6 +35,7 @@ class Code(StrEnum):
     EMPTY_STEP_ID = 'wic007'
     MALFORMED_WIC_STEP_KEY = 'wic008'
     UNKNOWN_TAG = 'wic009'
+    RECURSIVE_ALIAS = 'wic030'
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,11 +65,23 @@ class Diagnostics(Sequence[Diagnostic]):
 
     def error(self, code: Code, message: str, span: SourceSpan) -> None:
         """Record an error."""
-        self._items.append(Diagnostic(Severity.ERROR, code, message, span))
+        self._append(Diagnostic(Severity.ERROR, code, message, span))
 
     def warn(self, code: Code, message: str, span: SourceSpan) -> None:
         """Record a warning."""
-        self._items.append(Diagnostic(Severity.WARNING, code, message, span))
+        self._append(Diagnostic(Severity.WARNING, code, message, span))
+
+    def _append(self, diagnostic: Diagnostic) -> None:
+        """Append, dropping exact duplicates.
+
+        Several parse paths legitimately visit the same node — a key is read
+        once to find `id:` and again to build the body — and a diagnostic-
+        emitting helper called twice would otherwise report the same problem
+        twice at the same position. `Diagnostic` is frozen, so identity is
+        equality of all four fields; a repeat adds nothing a reader could use.
+        """
+        if diagnostic not in self._items:
+            self._items.append(diagnostic)
 
     @property
     def has_errors(self) -> bool:
@@ -81,7 +94,7 @@ class Diagnostics(Sequence[Diagnostic]):
     @overload
     def __getitem__(self, index: slice) -> 'Diagnostics': ...
 
-    def __getitem__(self, index: int | slice) -> "Diagnostic | Diagnostics":
+    def __getitem__(self, index: int | slice) -> 'Diagnostic | Diagnostics':
         if isinstance(index, slice):
             return Diagnostics(self._items[index])
         return self._items[index]

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -1,0 +1,87 @@
+"""Structured diagnostics.
+
+Parsing reports problems as values rather than raising, so a caller can decide
+what to do with them and a malformed document can yield several errors in one
+pass instead of one per run. See design_docs/core-refactor-design.md, Spec 1.
+"""
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .spans import SourceSpan
+
+
+class Severity(StrEnum):
+    """How much a diagnostic matters."""
+
+    ERROR = 'error'
+    WARNING = 'warning'
+
+
+class Code(StrEnum):
+    """Stable identifiers for diagnostics.
+
+    Codes are part of the contract: they can be matched on, suppressed, and
+    documented, whereas message wording is free to improve.
+    """
+
+    INVALID_YAML = 'wic001'
+    NOT_A_MAPPING = 'wic002'
+    EXPECTED_MAPPING = 'wic003'
+    EXPECTED_SEQUENCE = 'wic004'
+    EXPECTED_SCALAR = 'wic005'
+    MISSING_STEP_ID = 'wic006'
+    EMPTY_STEP_ID = 'wic007'
+    MALFORMED_WIC_STEP_KEY = 'wic008'
+    UNKNOWN_TAG = 'wic009'
+
+
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    """A single problem, located in source."""
+
+    severity: Severity
+    code: Code
+    message: str
+    span: SourceSpan
+
+    def __str__(self) -> str:
+        return f'{self.span}: {self.severity} [{self.code}] {self.message}'
+
+
+class Diagnostics(Sequence[Diagnostic]):
+    """An ordered, append-only collection of diagnostics.
+
+    Implemented as a `Sequence` so callers can index, iterate, and take a
+    length without reaching for an attribute.
+    """
+
+    __slots__ = ('_items',)
+
+    def __init__(self, items: Iterable[Diagnostic] = ()) -> None:
+        self._items: list[Diagnostic] = list(items)
+
+    def error(self, code: Code, message: str, span: SourceSpan) -> None:
+        """Record an error."""
+        self._items.append(Diagnostic(Severity.ERROR, code, message, span))
+
+    def warn(self, code: Code, message: str, span: SourceSpan) -> None:
+        """Record a warning."""
+        self._items.append(Diagnostic(Severity.WARNING, code, message, span))
+
+    @property
+    def has_errors(self) -> bool:
+        """Whether any recorded diagnostic is an error."""
+        return any(d.severity is Severity.ERROR for d in self._items)
+
+    def __getitem__(self, index: int) -> Diagnostic:  # type: ignore[override]
+        return self._items[index]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[Diagnostic]:
+        return iter(self._items)
+
+    def __repr__(self) -> str:
+        return f'Diagnostics({self._items!r})'

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -5,6 +5,7 @@ what to do with them and a malformed document can yield several errors in one
 pass instead of one per run. See design_docs/core-refactor-design.md, Spec 1.
 """
 from collections.abc import Iterable, Iterator, Sequence
+from typing import overload
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -74,7 +75,15 @@ class Diagnostics(Sequence[Diagnostic]):
         """Whether any recorded diagnostic is an error."""
         return any(d.severity is Severity.ERROR for d in self._items)
 
-    def __getitem__(self, index: int) -> Diagnostic:  # type: ignore[override]
+    @overload
+    def __getitem__(self, index: int) -> Diagnostic: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> 'Diagnostics': ...
+
+    def __getitem__(self, index: int | slice) -> "Diagnostic | Diagnostics":
+        if isinstance(index, slice):
+            return Diagnostics(self._items[index])
         return self._items[index]
 
     def __len__(self) -> int:

--- a/src/sophios/lang/nodes.py
+++ b/src/sophios/lang/nodes.py
@@ -1,7 +1,7 @@
-"""Typed AST for the `.wic` language.
+"""Typed AST for the Sophios language.
 
 The nodes here are the executable specification of the syntax layer: what a
-well-formed `.wic` document may contain, independent of which tools happen to
+well-formed Sophios document may contain, independent of which tools happen to
 be installed. See design_docs/core-refactor-design.md, Spec 1.
 
 Every node is frozen and slotted. Frozen because an AST that consumers can
@@ -142,7 +142,7 @@ class WicSidecar:
 
 @dataclass(frozen=True, slots=True)
 class Document:
-    """A parsed `.wic` document.
+    """A parsed Sophios document.
 
     `passthrough` carries every top-level key Sophios does not interpret —
     `$namespaces`, `$schemas`, `requirements`, `hints`, and anything else —

--- a/src/sophios/lang/nodes.py
+++ b/src/sophios/lang/nodes.py
@@ -1,0 +1,161 @@
+"""Typed AST for the `.wic` language.
+
+The nodes here are the executable specification of the syntax layer: what a
+well-formed `.wic` document may contain, independent of which tools happen to
+be installed. See design_docs/core-refactor-design.md, Spec 1.
+
+Every node is frozen and slotted. Frozen because an AST that consumers can
+mutate is not a specification of anything; slotted because these are allocated
+once per construct in a document and the dict-per-instance overhead is pure
+waste.
+"""
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+from .spans import SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class InlineLiteral:
+    """`!ii value` — a literal, never an edge."""
+
+    value: Any
+    span: SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeDef:
+    """`!& name` — an explicit edge definition site."""
+
+    name: str
+    span: SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeRef:
+    """`!* name` — an explicit edge call site."""
+
+    name: str
+    span: SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class RawCwlRef:
+    """`!cwl expression` — an opaque CWL reference, passed through unresolved.
+
+    The compiler does not attempt to interpret the expression. This is the
+    local, visible form of what `--allow_raw_cwl` does globally.
+    """
+
+    expression: str
+    span: SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class UnresolvedName:
+    """A bare string that must resolve to a workflow input.
+
+    If it does not, resolution reports a diagnostic naming both remedies:
+    `!ii` for a literal, `!cwl` for a raw CWL reference.
+    """
+
+    name: str
+    span: SourceSpan
+
+
+#: The complete set of forms a step input may take. Closed by construction:
+#: the parser produces nothing outside this union, so exhaustive `match`
+#: statements over it stay exhaustive.
+InputValue: TypeAlias = InlineLiteral | EdgeDef | EdgeRef | RawCwlRef | UnresolvedName
+
+#: CWL that Sophios does not interpret and passes through unchanged. Modelled
+#: as opaque on purpose: nothing downstream should reason about its interior.
+OpaqueCwl: TypeAlias = Any
+
+
+@dataclass(frozen=True, slots=True)
+class OutputBinding:
+    """One entry of a step's `out:` list.
+
+    Either a bare name (`- file`) or a single-key mapping binding that name to
+    an edge definition (`- file: !& file_touch`).
+    """
+
+    name: str
+    edge_def: EdgeDef | None
+    span: SourceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class Step:
+    """A single workflow step.
+
+    `interpreted` holds the CWL keys Sophios acts upon (`scatter`,
+    `scatterMethod`, `when`, `run`); `passthrough` holds everything else,
+    preserved verbatim.
+    """
+
+    id: str
+    inputs: tuple[tuple[str, InputValue], ...] = ()
+    outputs: tuple[OutputBinding, ...] = ()
+    interpreted: tuple[tuple[str, OpaqueCwl], ...] = ()
+    passthrough: tuple[tuple[str, OpaqueCwl], ...] = ()
+    span: SourceSpan | None = None
+
+    def input(self, name: str) -> InputValue | None:
+        """Return the value bound to `name`, or None if unbound."""
+        return next((v for k, v in self.inputs if k == name), None)
+
+
+@dataclass(frozen=True, slots=True)
+class StepKey:
+    """A `wic:` sidecar step key, normalised from its `"(1, name)"` form.
+
+    The surface syntax is retained for compatibility, but nothing downstream
+    should ever parse that string again.
+    """
+
+    index: int
+    name: str
+
+    def __str__(self) -> str:
+        return f'({self.index}, {self.name})'
+
+
+@dataclass(frozen=True, slots=True)
+class WicSidecar:
+    """The `wic:` metadata block.
+
+    `steps` is normalised to `StepKey`; every other key (`graphviz`,
+    `default_implementation`, `namespace`, ...) is retained verbatim, because
+    the sidecar's surface is unchanged by this specification.
+    """
+
+    steps: tuple[tuple[StepKey, 'WicSidecar'], ...] = ()
+    entries: tuple[tuple[str, OpaqueCwl], ...] = ()
+    span: SourceSpan | None = None
+
+    def entry(self, name: str) -> OpaqueCwl | None:
+        """Return a non-`steps` sidecar entry by name."""
+        return next((v for k, v in self.entries if k == name), None)
+
+
+@dataclass(frozen=True, slots=True)
+class Document:
+    """A parsed `.wic` document.
+
+    `passthrough` carries every top-level key Sophios does not interpret —
+    `$namespaces`, `$schemas`, `requirements`, `hints`, and anything else —
+    preserved so it can be emitted unchanged.
+    """
+
+    steps: tuple[Step, ...] = ()
+    sidecar: WicSidecar | None = None
+    passthrough: tuple[tuple[str, OpaqueCwl], ...] = ()
+    span: SourceSpan | None = None
+    #: True when `steps:` was written as a mapping rather than a sequence.
+    steps_as_mapping: bool = field(default=False)
+
+    def step(self, step_id: str) -> Step | None:
+        """Return the first step with the given id, or None."""
+        return next((s for s in self.steps if s.id == step_id), None)

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -49,16 +49,6 @@ INTERPRETED_STEP_KEYS: Final = frozenset({'scatter', 'scatterMethod', 'when', 'r
 #: `wic:` sidecar step keys have the surface form "(1, step_name)".
 _WIC_STEP_KEY: Final = re.compile(r'^\(\s*(\d+)\s*,\s*(.+?)\s*\)$')
 
-#: How YAML's resolved scalar tags map to Python values. Annotated explicitly
-#: because the converters are heterogeneous and would otherwise infer as
-#: `object`, which is not callable.
-_SCALAR_TAGS: Final[dict[str, Callable[[str], Any]]] = {
-    'tag:yaml.org,2002:null': lambda _: None,
-    'tag:yaml.org,2002:bool': lambda s: s.lower() in ('true', 'yes', 'on'),
-    'tag:yaml.org,2002:int': int,
-    'tag:yaml.org,2002:float': float,
-}
-
 
 @dataclass(frozen=True, slots=True)
 class ParseResult:
@@ -120,7 +110,7 @@ def _document(root: yaml.nodes.MappingNode, file: str, diags: Diagnostics) -> Do
     passthrough: list[tuple[str, OpaqueCwl]] = []
 
     for key_node, value_node in root.value:
-        key = _key_text(key_node)
+        key = _key_text(key_node, file, diags)
         match key:
             case 'steps':
                 steps, steps_as_mapping = _steps(value_node, file, diags)
@@ -146,7 +136,7 @@ def _steps(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[tuple[
     """
     match node:
         case yaml.nodes.MappingNode():
-            return tuple(_step(_key_text(k), v, file, diags) for k, v in node.value), True
+            return tuple(_step(_key_text(k, file, diags), v, file, diags) for k, v in node.value), True
         case yaml.nodes.SequenceNode():
             return tuple(_sequence_step(item, file, diags) for item in node.value), False
         case _:
@@ -174,17 +164,17 @@ def _sequence_step(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Step
         diags.error(Code.EXPECTED_MAPPING, f'each step must be a mapping, found {_kind(node)}', span)
         return Step(id='', span=span)
 
-    id_node = next((v for k, v in node.value if _key_text(k) == 'id'), None)
+    id_node = next((v for k, v in node.value if _key_text(k, file, diags) == 'id'), None)
     if id_node is not None:
         step_id = _name_text(id_node)
         if not step_id:
             diags.error(Code.EMPTY_STEP_ID, 'id: must be a non-empty string', SourceSpan.of(file, id_node))
-        body = [(k, v) for k, v in node.value if _key_text(k) != 'id']
+        body = [(k, v) for k, v in node.value if _key_text(k, file, diags) != 'id']
         return _step_body(step_id, body, span, file, diags)
 
     if len(node.value) == 1:
         key_node, value_node = node.value[0]
-        return _step(_key_text(key_node), value_node, file, diags)
+        return _step(_key_text(key_node, file, diags), value_node, file, diags)
 
     diags.error(
         Code.MISSING_STEP_ID,
@@ -223,7 +213,7 @@ def _step_body(
     passthrough: list[tuple[str, OpaqueCwl]] = []
 
     for key_node, value_node in entries:
-        key = _key_text(key_node)
+        key = _key_text(key_node, file, diags)
         if key == 'in':
             inputs = _inputs(value_node, file, diags)
         elif key == 'out':
@@ -248,7 +238,7 @@ def _inputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[tuple
     if not isinstance(node, yaml.nodes.MappingNode):
         diags.error(Code.EXPECTED_MAPPING, f'in: must be a mapping, found {_kind(node)}', SourceSpan.of(file, node))
         return ()
-    return tuple((_key_text(k), _input_value(v, file, diags)) for k, v in node.value)
+    return tuple((_key_text(k, file, diags), _input_value(v, file, diags)) for k, v in node.value)
 
 
 def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputValue:
@@ -275,6 +265,13 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     if desugared is not None:
         return desugared
 
+    if node.tag.startswith('!'):
+        # A tag the language does not own. The loader rejects this outright,
+        # and the specification must never be more permissive than the thing
+        # it specifies; the payload is kept, untagged, for recovery.
+        diags.error(Code.UNKNOWN_TAG,
+                    f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl', span)
+
     if isinstance(node, yaml.nodes.ScalarNode):
         return UnresolvedName(node.value, span)
     # A bare mapping or sequence cannot name a workflow input, so it is only
@@ -292,7 +289,7 @@ def _desugared_form(
     if not isinstance(node, yaml.nodes.MappingNode) or len(node.value) != 1:
         return None
     key_node, value_node = node.value[0]
-    build = _DESUGARED_FORMS.get(_key_text(key_node))
+    build = _DESUGARED_FORMS.get(_key_text(key_node, file, diags))
     if build is None:
         return None
     return build(value_node, file, diags, span)
@@ -337,7 +334,7 @@ def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Out
             key_node, value_node = node.value[0]
             edge = value_node.tag == TAG_ANCHOR
             return OutputBinding(
-                _key_text(key_node),
+                _key_text(key_node, file, diags),
                 EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node)) if edge else None,
                 span,
             )
@@ -364,7 +361,7 @@ def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar
     entries: list[tuple[str, OpaqueCwl]] = []
 
     for key_node, value_node in node.value:
-        key = _key_text(key_node)
+        key = _key_text(key_node, file, diags)
         if key != 'steps':
             entries.append((key, _opaque(value_node, file, diags)))
             continue
@@ -376,11 +373,11 @@ def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar
             )
             continue
         for sub_key, sub_value in value_node.value:
-            parsed = _step_key(_key_text(sub_key))
+            parsed = _step_key(_key_text(sub_key, file, diags))
             if parsed is None:
                 diags.error(
                     Code.MALFORMED_WIC_STEP_KEY,
-                    f'wic: step key {_key_text(sub_key)!r} must have the form "(index, name)"',
+                    f'wic: step key {_key_text(sub_key, file, diags)!r} must have the form "(index, name)"',
                     SourceSpan.of(file, sub_key),
                 )
                 continue
@@ -428,30 +425,43 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
     that an edge reference buried in passthrough is not silently flattened to
     a plain string.
     """
+    if node.tag.startswith('!') and node.tag not in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
+        # Passthrough is CWL, and CWL has no custom YAML tags: the loader
+        # rejects this text, so accepting it here would specify a superset of
+        # the language. Reported; the payload is materialised for recovery.
+        diags.error(Code.UNKNOWN_TAG,
+                    f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl',
+                    SourceSpan.of(file, node))
+
     match node:
         case yaml.nodes.ScalarNode():
             if node.tag in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
                 return _input_value(node, file, diags)
-            return _tagged_scalar(node)
+            return _resolved_scalar(node)
         case yaml.nodes.SequenceNode():
             return [_opaque(item, file, diags) for item in node.value]
         case yaml.nodes.MappingNode():
-            return {_key_text(k): _opaque(v, file, diags) for k, v in node.value}
-        case _:
-            diags.error(Code.UNKNOWN_TAG, f'unsupported node {_kind(node)}', SourceSpan.of(file, node))
-            return None
+            return {_key_text(k, file, diags): _opaque(v, file, diags) for k, v in node.value}
+        case _:  # pragma: no cover — compose() emits only the three kinds above
+            return node.value
 
 
-def _tagged_scalar(node: yaml.nodes.ScalarNode) -> Any:
-    """Convert a resolved scalar node to its Python value."""
-    convert = _SCALAR_TAGS.get(node.tag)
-    if convert is None:
-        return node.value
+def _resolved_scalar(node: yaml.nodes.ScalarNode) -> Any:
+    """Convert a resolved scalar node to its Python value, exactly as the
+    loader would.
+
+    Delegated to PyYAML's own `SafeConstructor` rather than re-implemented:
+    a hand-written table diverged from the loader on octals, hex, timestamps,
+    `.inf`, and sexagesimals, which is precisely the "specification quietly
+    changes what existing documents mean" this module exists to prevent. A
+    fresh constructor per call — the class carries per-document state, and
+    this layer is shared across threads.
+    """
     try:
-        return convert(node.value)
-    except ValueError:
-        # The resolver claimed a type the text cannot actually produce; the raw
-        # text is the honest fallback.
+        return yaml.constructor.SafeConstructor().construct_object(node)
+    except yaml.constructor.ConstructorError:
+        # The resolver claimed a type the text cannot produce; the raw text
+        # is the honest fallback.
         return node.value
 
 
@@ -465,13 +475,17 @@ def _name_text(node: yaml.nodes.Node) -> str:
     return str(node.value) if isinstance(node, yaml.nodes.ScalarNode) else ''
 
 
-def _scalar(node: yaml.nodes.Node) -> Any:
-    """Return a scalar node's value, or None for any other node kind."""
-    return _tagged_scalar(node) if isinstance(node, yaml.nodes.ScalarNode) else None
+def _key_text(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> str:
+    """Return a mapping key as text.
 
-
-def _key_text(node: yaml.nodes.Node) -> str:
-    """Return a mapping key as text."""
+    YAML admits collection keys (`? [a, b]`); Sophios does not — every key in
+    the language is a name. A non-scalar key is reported and stringified for
+    recovery, rather than silently becoming the repr of a node list.
+    """
+    if not isinstance(node, yaml.nodes.ScalarNode):
+        diags.error(Code.EXPECTED_SCALAR,
+                    f'mapping keys must be scalars, found {_kind(node)}',
+                    SourceSpan.of(file, node))
     return str(node.value)
 
 

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -14,7 +14,7 @@ from typing import Any, Final
 
 import yaml
 
-from ..utils_yaml import TAG_ALIAS, TAG_ANCHOR, TAG_INLINE_INPUT
+from ..utils_yaml import KEY_ALIAS, KEY_ANCHOR, KEY_INLINE_INPUT, TAG_ALIAS, TAG_ANCHOR, TAG_INLINE_INPUT
 from .diagnostics import Code, Diagnostics
 from .nodes import (
     Document,
@@ -35,6 +35,11 @@ from .spans import SourceSpan
 #: `!cwl expr` — the per-value escape hatch. Additive: files that do not use it
 #: are unaffected, and it is the local form of the global --allow_raw_cwl flag.
 TAG_RAW_CWL: Final = '!cwl'
+
+#: The desugared key for `!cwl`, mirroring KEY_ANCHOR / KEY_ALIAS /
+#: KEY_INLINE_INPUT in utils_yaml. Every construct has both a tagged and a
+#: desugared form so the Python API can emit documents that reload unchanged.
+KEY_RAW_CWL: Final = 'wic_raw_cwl'
 
 #: CWL keys on a step that Sophios reads *and acts upon*. Everything else on a
 #: step is passthrough, by definition. Enumerating this set is what makes the
@@ -171,7 +176,7 @@ def _sequence_step(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Step
 
     id_node = next((v for k, v in node.value if _key_text(k) == 'id'), None)
     if id_node is not None:
-        step_id = str(_scalar(id_node) or '')
+        step_id = _name_text(id_node)
         if not step_id:
             diags.error(Code.EMPTY_STEP_ID, 'id: must be a non-empty string', SourceSpan.of(file, id_node))
         body = [(k, v) for k, v in node.value if _key_text(k) != 'id']
@@ -249,25 +254,69 @@ def _inputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[tuple
 def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputValue:
     """Classify one step input into the closed `InputValue` union.
 
-    The tag decides the form. An untagged scalar is an `UnresolvedName`, which
-    resolution later either binds to a workflow input or reports on.
+    Each construct has two equivalent surface forms and both must produce the
+    same node (see the language reference, "Two surface forms"):
+
+        tagged     filename: !ii empty.txt
+        desugared  filename: {wic_inline_input: empty.txt}
+
+    Humans write the tagged form; the Python API emits the desugared form,
+    because a constructor that re-emitted its own tag would fire again on
+    reload. An untagged scalar is an `UnresolvedName`, which resolution later
+    binds to a workflow input or reports on.
     """
     span = SourceSpan.of(file, node)
-    match node.tag:
-        case t if t == TAG_INLINE_INPUT:
-            return InlineLiteral(_literal(node, file, diags), span)
-        case t if t == TAG_ANCHOR:
-            return EdgeDef(str(_scalar(node) or ''), span)
-        case t if t == TAG_ALIAS:
-            return EdgeRef(str(_scalar(node) or ''), span)
-        case t if t == TAG_RAW_CWL:
-            return RawCwlRef(str(_scalar(node) or ''), span)
-        case _:
-            if isinstance(node, yaml.nodes.ScalarNode):
-                return UnresolvedName(node.value, span)
-            # A bare mapping or sequence cannot name a workflow input, so it is
-            # only meaningful as a literal.
-            return InlineLiteral(_opaque(node, file, diags), span)
+
+    build = _TAGGED_FORMS.get(node.tag)
+    if build is not None:
+        return build(node, file, diags, span)
+
+    desugared = _desugared_form(node, file, diags, span)
+    if desugared is not None:
+        return desugared
+
+    if isinstance(node, yaml.nodes.ScalarNode):
+        return UnresolvedName(node.value, span)
+    # A bare mapping or sequence cannot name a workflow input, so it is only
+    # meaningful as a literal.
+    return InlineLiteral(_opaque(node, file, diags), span)
+
+
+def _desugared_form(
+    node: yaml.nodes.Node,
+    file: str,
+    diags: Diagnostics,
+    span: SourceSpan,
+) -> InputValue | None:
+    """Recognise the single-key mapping form of a wic construct, if present."""
+    if not isinstance(node, yaml.nodes.MappingNode) or len(node.value) != 1:
+        return None
+    key_node, value_node = node.value[0]
+    build = _DESUGARED_FORMS.get(_key_text(key_node))
+    if build is None:
+        return None
+    return build(value_node, file, diags, span)
+
+
+#: Tagged spellings to the node they build, paired with _DESUGARED_FORMS below.
+#: A table rather than a comparison chain: one lookup instead of four, and the
+#: two spellings of each construct stay side by side.
+_TAGGED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
+    TAG_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_literal(n, f, d), s),
+    TAG_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
+    TAG_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
+    TAG_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+}
+
+#: Desugared keys to the node they build. A table rather than a branch chain:
+#: adding a construct means adding a row, and the tagged and desugared spellings
+#: stay visibly paired.
+_DESUGARED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
+    KEY_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_opaque(n, f, d), s),
+    KEY_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
+    KEY_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
+    KEY_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+}
 
 
 def _outputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[OutputBinding, ...]:
@@ -289,7 +338,7 @@ def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Out
             edge = value_node.tag == TAG_ANCHOR
             return OutputBinding(
                 _key_text(key_node),
-                EdgeDef(str(_scalar(value_node) or ''), SourceSpan.of(file, value_node)) if edge else None,
+                EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node)) if edge else None,
                 span,
             )
         case _:
@@ -404,6 +453,16 @@ def _tagged_scalar(node: yaml.nodes.ScalarNode) -> Any:
         # The resolver claimed a type the text cannot actually produce; the raw
         # text is the honest fallback.
         return node.value
+
+
+def _name_text(node: yaml.nodes.Node) -> str:
+    """Return a scalar node's literal text.
+
+    Edge names and CWL references are identifiers, so the raw text is what is
+    meant — resolving `false` to a bool, or `01` to an int, would rename them.
+    This matches `anchor_constructor`, which uses `construct_scalar`.
+    """
+    return str(node.value) if isinstance(node, yaml.nodes.ScalarNode) else ''
 
 
 def _scalar(node: yaml.nodes.Node) -> Any:

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -166,7 +166,7 @@ def _sequence_step(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Step
 
     id_node = next((v for k, v in node.value if _key_text(k, file, diags) == 'id'), None)
     if id_node is not None:
-        step_id = _name_text(id_node)
+        step_id = _name_text(id_node, file, diags)
         if not step_id:
             diags.error(Code.EMPTY_STEP_ID, 'id: must be a non-empty string', SourceSpan.of(file, id_node))
         body = [(k, v) for k, v in node.value if _key_text(k, file, diags) != 'id']
@@ -300,9 +300,9 @@ def _desugared_form(
 #: two spellings of each construct stay side by side.
 _TAGGED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
     TAG_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_literal(n, f, d), s),
-    TAG_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
-    TAG_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
-    TAG_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+    TAG_ANCHOR: lambda n, f, d, s: EdgeDef(_name_text(n, f, d), s),
+    TAG_ALIAS: lambda n, f, d, s: EdgeRef(_name_text(n, f, d), s),
+    TAG_RAW_CWL: lambda n, f, d, s: RawCwlRef(_name_text(n, f, d), s),
 }
 
 #: Desugared keys to the node they build. A table rather than a branch chain:
@@ -310,9 +310,9 @@ _TAGGED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, Sour
 #: stay visibly paired.
 _DESUGARED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
     KEY_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_opaque(n, f, d), s),
-    KEY_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
-    KEY_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
-    KEY_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+    KEY_ANCHOR: lambda n, f, d, s: EdgeDef(_name_text(n, f, d), s),
+    KEY_ALIAS: lambda n, f, d, s: EdgeRef(_name_text(n, f, d), s),
+    KEY_RAW_CWL: lambda n, f, d, s: RawCwlRef(_name_text(n, f, d), s),
 }
 
 
@@ -374,11 +374,11 @@ def _child_sidecar_node(node: yaml.nodes.Node) -> yaml.nodes.Node:
 def _out_edge_def(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> EdgeDef | None:
     """Recognise an edge definition in either spelling, or None."""
     if node.tag == TAG_ANCHOR:
-        return EdgeDef(_name_text(node), SourceSpan.of(file, node))
+        return EdgeDef(_name_text(node, file, diags), SourceSpan.of(file, node))
     if isinstance(node, yaml.nodes.MappingNode) and len(node.value) == 1:
         key_node, value_node = node.value[0]
         if _key_text(key_node, file, diags) == KEY_ANCHOR:
-            return EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node))
+            return EdgeDef(_name_text(value_node, file, diags), SourceSpan.of(file, value_node))
     return None
 
 
@@ -448,7 +448,7 @@ def _literal(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Any:
     quietly change what existing documents mean.
     """
     if not isinstance(node, yaml.nodes.ScalarNode):
-        return _opaque(node, file, diags)
+        return _opaque(node, file, diags, _wrap_self=False)
     if node.value == '':
         return ''
     try:
@@ -465,7 +465,8 @@ _EXPANSION_BUDGET: Final = 100_000
 
 
 def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
-            _path: frozenset[int] = frozenset(), _spent: list[int] | None = None) -> OpaqueCwl:
+            _path: frozenset[int] = frozenset(), _spent: list[int] | None = None,
+            _wrap_self: bool = True) -> OpaqueCwl:
     """Materialise a node Sophios does not interpret, preserving it verbatim.
 
     Custom wic tags are still recognised inside otherwise-opaque content so
@@ -496,17 +497,36 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
                     f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl',
                     SourceSpan.of(file, node))
 
+    if node.tag in (TAG_ANCHOR, TAG_ALIAS, TAG_RAW_CWL) or (
+            node.tag == TAG_INLINE_INPUT and isinstance(node, yaml.nodes.ScalarNode)):
+        # Name-carrying tags route through the construct builder whatever the
+        # node kind: `!& []` is a diagnostic — a name cannot be a collection,
+        # and the loader rejects the same text. Falling through would strip
+        # the tag silently. Scalar `!ii` routes the same way; collection `!ii`
+        # is handled below, on the materialised content, because its builder
+        # would call back into this walk on the very same node.
+        return _input_value(node, file, diags)
+
+    content: OpaqueCwl
     match node:
+        case yaml.nodes.ScalarNode() if node.tag == TAG_INLINE_INPUT:
+            content = None  # pragma: no cover — routed above; keeps match total
         case yaml.nodes.ScalarNode():
-            if node.tag in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
-                return _input_value(node, file, diags)
-            return _resolved_scalar(node)
+            content = _resolved_scalar(node)
         case yaml.nodes.SequenceNode():
-            return [_opaque(item, file, diags, path, spent) for item in node.value]
+            content = [_opaque(item, file, diags, path, spent) for item in node.value]
         case yaml.nodes.MappingNode():
-            return {_key_text(k, file, diags): _opaque(v, file, diags, path, spent) for k, v in node.value}
+            content = {_key_text(k, file, diags): _opaque(v, file, diags, path, spent) for k, v in node.value}
         case _:  # pragma: no cover — compose() emits only the three kinds above
-            return node.value
+            content = node.value
+
+    if node.tag == TAG_INLINE_INPUT and _wrap_self:
+        # A collection literal: `!ii {a: 1}` in passthrough is the same
+        # construct as in input position, wrapped around its materialised
+        # content rather than re-dispatched into an infinite loop. `_literal`
+        # passes _wrap_self=False because its caller already wraps.
+        return InlineLiteral(content, SourceSpan.of(file, node))
+    return content
 
 
 def _resolved_scalar(node: yaml.nodes.ScalarNode) -> Any:
@@ -528,14 +548,21 @@ def _resolved_scalar(node: yaml.nodes.ScalarNode) -> Any:
         return node.value
 
 
-def _name_text(node: yaml.nodes.Node) -> str:
-    """Return a scalar node's literal text.
+def _name_text(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> str:
+    """Return a scalar node's literal text, reporting anything non-scalar.
 
     Edge names and CWL references are identifiers, so the raw text is what is
     meant — resolving `false` to a bool, or `01` to an int, would rename them.
-    This matches `anchor_constructor`, which uses `construct_scalar`.
+    This matches `anchor_constructor`, which uses `construct_scalar` — and,
+    like it, a collection is an error: `!& []` names nothing, and the loader
+    rejects the same text with a ConstructorError.
     """
-    return str(node.value) if isinstance(node, yaml.nodes.ScalarNode) else ''
+    if not isinstance(node, yaml.nodes.ScalarNode):
+        diags.error(Code.EXPECTED_SCALAR,
+                    f'an edge or reference name must be a scalar, found {_kind(node)}',
+                    SourceSpan.of(file, node))
+        return ''
+    return str(node.value)
 
 
 def _key_text(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> str:

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -99,7 +99,7 @@ def parse(text: str, filename: str = '<string>') -> ParseResult:
     if not isinstance(root, yaml.nodes.MappingNode):
         diagnostics.error(
             Code.NOT_A_MAPPING,
-            f'a .wic document must be a mapping, found {_kind(root)}',
+            f'a Sophios document must be a mapping, found {_kind(root)}',
             SourceSpan.of(filename, root),
         )
         return ParseResult(None, diagnostics)

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -14,7 +14,16 @@ from typing import Any, Final
 
 import yaml
 
-from ..utils_yaml import KEY_ALIAS, KEY_ANCHOR, KEY_INLINE_INPUT, TAG_ALIAS, TAG_ANCHOR, TAG_INLINE_INPUT
+from ..utils_yaml import (
+    KEY_ALIAS,
+    KEY_ANCHOR,
+    KEY_INLINE_INPUT,
+    KEY_RAW_CWL,
+    TAG_ALIAS,
+    TAG_ANCHOR,
+    TAG_INLINE_INPUT,
+    TAG_RAW_CWL,
+)
 from .diagnostics import Code, Diagnostics
 from .nodes import (
     Document,
@@ -31,15 +40,6 @@ from .nodes import (
     WicSidecar,
 )
 from .spans import SourceSpan
-
-#: `!cwl expr` — the per-value escape hatch. Additive: files that do not use it
-#: are unaffected, and it is the local form of the global --allow_raw_cwl flag.
-TAG_RAW_CWL: Final = '!cwl'
-
-#: The desugared key for `!cwl`, mirroring KEY_ANCHOR / KEY_ALIAS /
-#: KEY_INLINE_INPUT in utils_yaml. Every construct has both a tagged and a
-#: desugared form so the Python API can emit documents that reload unchanged.
-KEY_RAW_CWL: Final = 'wic_raw_cwl'
 
 #: CWL keys on a step that Sophios reads *and acts upon*. Everything else on a
 #: step is passthrough, by definition. Enumerating this set is what makes the
@@ -261,16 +261,16 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     if build is not None:
         return build(node, file, diags, span)
 
-    desugared = _desugared_form(node, file, diags, span)
-    if desugared is not None:
-        return desugared
-
     if node.tag.startswith('!'):
         # A tag the language does not own. The loader rejects this outright,
         # and the specification must never be more permissive than the thing
         # it specifies; the payload is kept, untagged, for recovery.
         diags.error(Code.UNKNOWN_TAG,
                     f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl', span)
+
+    desugared = _desugared_form(node, file, diags, span)
+    if desugared is not None:
+        return desugared
 
     if isinstance(node, yaml.nodes.ScalarNode):
         return UnresolvedName(node.value, span)
@@ -332,12 +332,19 @@ def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Out
             return OutputBinding(node.value, None, span)
         case yaml.nodes.MappingNode() if len(node.value) == 1:
             key_node, value_node = node.value[0]
-            edge = value_node.tag == TAG_ANCHOR
-            return OutputBinding(
-                _key_text(key_node, file, diags),
-                EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node)) if edge else None,
-                span,
-            )
+            name = _key_text(key_node, file, diags)
+            edge = _out_edge_def(value_node, file, diags)
+            if edge is None:
+                # The value was not an edge definition in either spelling.
+                # Report it rather than let it vanish: the AST promises to
+                # preserve what it was given, and a silent drop is the one
+                # thing a total parser must never do.
+                diags.error(
+                    Code.EXPECTED_SCALAR,
+                    f'out: entry {name!r} must bind an !& edge definition; its value is neither !& nor wic_anchor',
+                    SourceSpan.of(file, value_node),
+                )
+            return OutputBinding(name, edge, span)
         case _:
             diags.error(
                 Code.EXPECTED_SCALAR,
@@ -347,9 +354,41 @@ def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Out
             return OutputBinding('', None, span)
 
 
-def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar:
+def _child_sidecar_node(node: yaml.nodes.Node) -> yaml.nodes.Node:
+    """Unwrap the `wic:` key a nested sidecar step carries on the surface.
+
+    `wic: steps: (1, outer):` holds `{wic: {steps: ...}}`, not a bare sidecar
+    (see docs/advanced.md and reference §5). Without the unwrap, everything at
+    depth two or more sat in `entries` as opaque content and `(1, inner)` was
+    never normalised to a `StepKey` — falsifying the very docstring that says
+    nobody downstream should ever parse that string again.
+    """
+    if isinstance(node, yaml.nodes.MappingNode) and len(node.value) == 1:
+        key_node, value_node = node.value[0]
+        if getattr(key_node, 'value', None) == 'wic':
+            assert isinstance(value_node, yaml.nodes.Node)  # untyped tuple from PyYAML
+            return value_node
+    return node
+
+
+def _out_edge_def(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> EdgeDef | None:
+    """Recognise an edge definition in either spelling, or None."""
+    if node.tag == TAG_ANCHOR:
+        return EdgeDef(_name_text(node), SourceSpan.of(file, node))
+    if isinstance(node, yaml.nodes.MappingNode) and len(node.value) == 1:
+        key_node, value_node = node.value[0]
+        if _key_text(key_node, file, diags) == KEY_ANCHOR:
+            return EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node))
+    return None
+
+
+def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics,
+             _path: frozenset[int] = frozenset()) -> WicSidecar:
     """Parse a `wic:` block, normalising its `"(1, name)"` step keys."""
     span = SourceSpan.of(file, node)
+    if id(node) in _path:
+        diags.error(Code.RECURSIVE_ALIAS, 'alias cycle: a wic: block contains itself', span)
+        return WicSidecar(span=span)
     if node.tag == 'tag:yaml.org,2002:null':
         # `wic:` with nothing under it is an empty sidecar, not an error.
         return WicSidecar(span=span)
@@ -373,15 +412,16 @@ def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar
             )
             continue
         for sub_key, sub_value in value_node.value:
-            parsed = _step_key(_key_text(sub_key, file, diags))
+            key_text = _key_text(sub_key, file, diags)
+            parsed = _step_key(key_text)
             if parsed is None:
                 diags.error(
                     Code.MALFORMED_WIC_STEP_KEY,
-                    f'wic: step key {_key_text(sub_key, file, diags)!r} must have the form "(index, name)"',
+                    f'wic: step key {key_text!r} must have the form "(index, name)"',
                     SourceSpan.of(file, sub_key),
                 )
                 continue
-            steps.append((parsed, _sidecar(sub_value, file, diags)))
+            steps.append((parsed, _sidecar(_child_sidecar_node(sub_value), file, diags, _path | {id(node)})))
 
     return WicSidecar(steps=tuple(steps), entries=tuple(entries), span=span)
 
@@ -418,13 +458,36 @@ def _literal(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Any:
         return node.value
 
 
-def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
+#: Passthrough nodes materialised per parse before the walk is cut off. YAML
+#: aliases make exponential expansion writable in ten lines ("billion laughs");
+#: a real workflow is nowhere near this, so the ceiling only stops attacks.
+_EXPANSION_BUDGET: Final = 100_000
+
+
+def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
+            _path: frozenset[int] = frozenset(), _spent: list[int] | None = None) -> OpaqueCwl:
     """Materialise a node Sophios does not interpret, preserving it verbatim.
 
     Custom wic tags are still recognised inside otherwise-opaque content so
     that an edge reference buried in passthrough is not silently flattened to
     a plain string.
     """
+    # Totality against adversarial aliases: a node already on the current
+    # path is a cycle (compose() resolves an alias to the same object), and a
+    # widening alias chain is cut off by the budget. Both are reported once.
+    spent = _spent if _spent is not None else [0]
+    if id(node) in _path:
+        diags.error(Code.RECURSIVE_ALIAS, 'alias cycle: a node contains itself', SourceSpan.of(file, node))
+        return None
+    spent[0] += 1
+    if spent[0] > _EXPANSION_BUDGET:
+        if spent[0] == _EXPANSION_BUDGET + 1:  # report once, not per node
+            diags.error(Code.RECURSIVE_ALIAS,
+                        f'alias expansion exceeds {_EXPANSION_BUDGET} nodes; refusing to materialise',
+                        SourceSpan.of(file, node))
+        return None
+    path = _path | {id(node)}
+
     if node.tag.startswith('!') and node.tag not in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
         # Passthrough is CWL, and CWL has no custom YAML tags: the loader
         # rejects this text, so accepting it here would specify a superset of
@@ -439,9 +502,9 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
                 return _input_value(node, file, diags)
             return _resolved_scalar(node)
         case yaml.nodes.SequenceNode():
-            return [_opaque(item, file, diags) for item in node.value]
+            return [_opaque(item, file, diags, path, spent) for item in node.value]
         case yaml.nodes.MappingNode():
-            return {_key_text(k, file, diags): _opaque(v, file, diags) for k, v in node.value}
+            return {_key_text(k, file, diags): _opaque(v, file, diags, path, spent) for k, v in node.value}
         case _:  # pragma: no cover — compose() emits only the three kinds above
             return node.value
 

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -1,0 +1,445 @@
+"""Parse `.wic` source into a typed AST.
+
+The parser composes YAML to a node tree rather than loading it to plain Python
+objects, because composition preserves the source marks that make diagnostics
+worth reading. Nothing here raises: a caller always receives a result carrying
+whatever was parsed plus whatever went wrong.
+
+See design_docs/core-refactor-design.md, Spec 1.
+"""
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Final
+
+import yaml
+
+from ..utils_yaml import TAG_ALIAS, TAG_ANCHOR, TAG_INLINE_INPUT
+from .diagnostics import Code, Diagnostics
+from .nodes import (
+    Document,
+    EdgeDef,
+    EdgeRef,
+    InlineLiteral,
+    InputValue,
+    OpaqueCwl,
+    OutputBinding,
+    RawCwlRef,
+    Step,
+    StepKey,
+    UnresolvedName,
+    WicSidecar,
+)
+from .spans import SourceSpan
+
+#: `!cwl expr` — the per-value escape hatch. Additive: files that do not use it
+#: are unaffected, and it is the local form of the global --allow_raw_cwl flag.
+TAG_RAW_CWL: Final = '!cwl'
+
+#: CWL keys on a step that Sophios reads *and acts upon*. Everything else on a
+#: step is passthrough, by definition. Enumerating this set is what makes the
+#: leak boundary a specification rather than an accident.
+INTERPRETED_STEP_KEYS: Final = frozenset({'scatter', 'scatterMethod', 'when', 'run'})
+
+#: `wic:` sidecar step keys have the surface form "(1, step_name)".
+_WIC_STEP_KEY: Final = re.compile(r'^\(\s*(\d+)\s*,\s*(.+?)\s*\)$')
+
+#: How YAML's resolved scalar tags map to Python values. Annotated explicitly
+#: because the converters are heterogeneous and would otherwise infer as
+#: `object`, which is not callable.
+_SCALAR_TAGS: Final[dict[str, Callable[[str], Any]]] = {
+    'tag:yaml.org,2002:null': lambda _: None,
+    'tag:yaml.org,2002:bool': lambda s: s.lower() in ('true', 'yes', 'on'),
+    'tag:yaml.org,2002:int': int,
+    'tag:yaml.org,2002:float': float,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ParseResult:
+    """The outcome of parsing one document.
+
+    `document` is None only when nothing could be recovered — malformed YAML,
+    or a root that is not a mapping. Otherwise it is present even alongside
+    errors, so a caller can report several problems at once.
+    """
+
+    document: Document | None
+    diagnostics: Diagnostics
+
+    @property
+    def ok(self) -> bool:
+        """Whether a document was produced with no errors."""
+        return self.document is not None and not self.diagnostics.has_errors
+
+
+def parse(text: str, filename: str = '<string>') -> ParseResult:
+    """Parse `.wic` source text into a `Document`.
+
+    This function is total: it never raises, for any input. Malformed YAML,
+    wrong node kinds, and unknown tags are all reported as diagnostics.
+    """
+    diagnostics = Diagnostics()
+    whole = SourceSpan(filename, 1, 1, text.count('\n') + 1, 1)
+
+    try:
+        root = yaml.compose(text, Loader=yaml.SafeLoader)
+    except yaml.YAMLError as exc:
+        diagnostics.error(Code.INVALID_YAML, _yaml_error_message(exc), _yaml_error_span(filename, exc, whole))
+        return ParseResult(None, diagnostics)
+
+    if root is None:  # An empty document is well-formed and carries nothing.
+        return ParseResult(Document(span=whole), diagnostics)
+
+    if not isinstance(root, yaml.nodes.MappingNode):
+        diagnostics.error(
+            Code.NOT_A_MAPPING,
+            f'a .wic document must be a mapping, found {_kind(root)}',
+            SourceSpan.of(filename, root),
+        )
+        return ParseResult(None, diagnostics)
+
+    return ParseResult(_document(root, filename, diagnostics), diagnostics)
+
+
+# --------------------------------------------------------------------------
+# Structure
+# --------------------------------------------------------------------------
+
+
+def _document(root: yaml.nodes.MappingNode, file: str, diags: Diagnostics) -> Document:
+    """Build a Document from the root mapping node."""
+    steps: tuple[Step, ...] = ()
+    steps_as_mapping = False
+    sidecar: WicSidecar | None = None
+    passthrough: list[tuple[str, OpaqueCwl]] = []
+
+    for key_node, value_node in root.value:
+        key = _key_text(key_node)
+        match key:
+            case 'steps':
+                steps, steps_as_mapping = _steps(value_node, file, diags)
+            case 'wic':
+                sidecar = _sidecar(value_node, file, diags)
+            case _:
+                passthrough.append((key, _opaque(value_node, file, diags)))
+
+    return Document(
+        steps=steps,
+        sidecar=sidecar,
+        passthrough=tuple(passthrough),
+        span=SourceSpan.of(file, root),
+        steps_as_mapping=steps_as_mapping,
+    )
+
+
+def _steps(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[tuple[Step, ...], bool]:
+    """Parse `steps:`, which may be a mapping or a sequence.
+
+    Both surface forms are long-standing and remain supported; the AST is the
+    same either way, so nothing downstream needs to care which was written.
+    """
+    match node:
+        case yaml.nodes.MappingNode():
+            return tuple(_step(_key_text(k), v, file, diags) for k, v in node.value), True
+        case yaml.nodes.SequenceNode():
+            return tuple(_sequence_step(item, file, diags) for item in node.value), False
+        case _:
+            diags.error(
+                Code.EXPECTED_MAPPING,
+                f'steps: must be a mapping or a sequence, found {_kind(node)}',
+                SourceSpan.of(file, node),
+            )
+            return (), False
+
+
+def _sequence_step(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Step:
+    """Parse one entry of a sequence-form `steps:`.
+
+    Two surface forms are in long-standing use and both remain supported:
+
+        - id: touch        # explicit id, body alongside it
+          in: {...}
+
+        - touch:           # single-key mapping, the key is the id
+            in: {...}
+    """
+    span = SourceSpan.of(file, node)
+    if not isinstance(node, yaml.nodes.MappingNode):
+        diags.error(Code.EXPECTED_MAPPING, f'each step must be a mapping, found {_kind(node)}', span)
+        return Step(id='', span=span)
+
+    id_node = next((v for k, v in node.value if _key_text(k) == 'id'), None)
+    if id_node is not None:
+        step_id = str(_scalar(id_node) or '')
+        if not step_id:
+            diags.error(Code.EMPTY_STEP_ID, 'id: must be a non-empty string', SourceSpan.of(file, id_node))
+        body = [(k, v) for k, v in node.value if _key_text(k) != 'id']
+        return _step_body(step_id, body, span, file, diags)
+
+    if len(node.value) == 1:
+        key_node, value_node = node.value[0]
+        return _step(_key_text(key_node), value_node, file, diags)
+
+    diags.error(
+        Code.MISSING_STEP_ID,
+        'a step in a sequence needs either an id: or a single name key',
+        span,
+    )
+    return Step(id='', span=span)
+
+
+def _step(step_id: str, node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Step:
+    """Parse a step body, keyed by its id.
+
+    A step may legitimately have no body at all (`some_step.wic:` with nothing
+    under it), which YAML resolves to null.
+    """
+    span = SourceSpan.of(file, node)
+    if node.tag == 'tag:yaml.org,2002:null':
+        return Step(id=step_id, span=span)
+    if not isinstance(node, yaml.nodes.MappingNode):
+        diags.error(Code.EXPECTED_MAPPING, f'step {step_id!r} must be a mapping, found {_kind(node)}', span)
+        return Step(id=step_id, span=span)
+    return _step_body(step_id, list(node.value), span, file, diags)
+
+
+def _step_body(
+    step_id: str,
+    entries: list[tuple[yaml.nodes.Node, yaml.nodes.Node]],
+    span: SourceSpan,
+    file: str,
+    diags: Diagnostics,
+) -> Step:
+    """Split a step's keys into inputs, outputs, interpreted CWL, and passthrough."""
+    inputs: tuple[tuple[str, InputValue], ...] = ()
+    outputs: tuple[OutputBinding, ...] = ()
+    interpreted: list[tuple[str, OpaqueCwl]] = []
+    passthrough: list[tuple[str, OpaqueCwl]] = []
+
+    for key_node, value_node in entries:
+        key = _key_text(key_node)
+        if key == 'in':
+            inputs = _inputs(value_node, file, diags)
+        elif key == 'out':
+            outputs = _outputs(value_node, file, diags)
+        elif key in INTERPRETED_STEP_KEYS:
+            interpreted.append((key, _opaque(value_node, file, diags)))
+        else:
+            passthrough.append((key, _opaque(value_node, file, diags)))
+
+    return Step(
+        id=step_id,
+        inputs=inputs,
+        outputs=outputs,
+        interpreted=tuple(interpreted),
+        passthrough=tuple(passthrough),
+        span=span,
+    )
+
+
+def _inputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[tuple[str, InputValue], ...]:
+    """Parse a step's `in:` mapping into typed input values."""
+    if not isinstance(node, yaml.nodes.MappingNode):
+        diags.error(Code.EXPECTED_MAPPING, f'in: must be a mapping, found {_kind(node)}', SourceSpan.of(file, node))
+        return ()
+    return tuple((_key_text(k), _input_value(v, file, diags)) for k, v in node.value)
+
+
+def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputValue:
+    """Classify one step input into the closed `InputValue` union.
+
+    The tag decides the form. An untagged scalar is an `UnresolvedName`, which
+    resolution later either binds to a workflow input or reports on.
+    """
+    span = SourceSpan.of(file, node)
+    match node.tag:
+        case t if t == TAG_INLINE_INPUT:
+            return InlineLiteral(_literal(node, file, diags), span)
+        case t if t == TAG_ANCHOR:
+            return EdgeDef(str(_scalar(node) or ''), span)
+        case t if t == TAG_ALIAS:
+            return EdgeRef(str(_scalar(node) or ''), span)
+        case t if t == TAG_RAW_CWL:
+            return RawCwlRef(str(_scalar(node) or ''), span)
+        case _:
+            if isinstance(node, yaml.nodes.ScalarNode):
+                return UnresolvedName(node.value, span)
+            # A bare mapping or sequence cannot name a workflow input, so it is
+            # only meaningful as a literal.
+            return InlineLiteral(_opaque(node, file, diags), span)
+
+
+def _outputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[OutputBinding, ...]:
+    """Parse a step's `out:` sequence."""
+    if not isinstance(node, yaml.nodes.SequenceNode):
+        diags.error(Code.EXPECTED_SEQUENCE, f'out: must be a sequence, found {_kind(node)}', SourceSpan.of(file, node))
+        return ()
+    return tuple(_output_binding(item, file, diags) for item in node.value)
+
+
+def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OutputBinding:
+    """Parse one `out:` entry: a bare name, or a name bound to an edge definition."""
+    span = SourceSpan.of(file, node)
+    match node:
+        case yaml.nodes.ScalarNode():
+            return OutputBinding(node.value, None, span)
+        case yaml.nodes.MappingNode() if len(node.value) == 1:
+            key_node, value_node = node.value[0]
+            edge = value_node.tag == TAG_ANCHOR
+            return OutputBinding(
+                _key_text(key_node),
+                EdgeDef(str(_scalar(value_node) or ''), SourceSpan.of(file, value_node)) if edge else None,
+                span,
+            )
+        case _:
+            diags.error(
+                Code.EXPECTED_SCALAR,
+                'each out: entry must be a name or a single-key mapping',
+                span,
+            )
+            return OutputBinding('', None, span)
+
+
+def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar:
+    """Parse a `wic:` block, normalising its `"(1, name)"` step keys."""
+    span = SourceSpan.of(file, node)
+    if node.tag == 'tag:yaml.org,2002:null':
+        # `wic:` with nothing under it is an empty sidecar, not an error.
+        return WicSidecar(span=span)
+    if not isinstance(node, yaml.nodes.MappingNode):
+        diags.error(Code.EXPECTED_MAPPING, f'wic: must be a mapping, found {_kind(node)}', span)
+        return WicSidecar(span=span)
+
+    steps: list[tuple[StepKey, WicSidecar]] = []
+    entries: list[tuple[str, OpaqueCwl]] = []
+
+    for key_node, value_node in node.value:
+        key = _key_text(key_node)
+        if key != 'steps':
+            entries.append((key, _opaque(value_node, file, diags)))
+            continue
+        if not isinstance(value_node, yaml.nodes.MappingNode):
+            diags.error(
+                Code.EXPECTED_MAPPING,
+                f'wic: steps: must be a mapping, found {_kind(value_node)}',
+                SourceSpan.of(file, value_node),
+            )
+            continue
+        for sub_key, sub_value in value_node.value:
+            parsed = _step_key(_key_text(sub_key))
+            if parsed is None:
+                diags.error(
+                    Code.MALFORMED_WIC_STEP_KEY,
+                    f'wic: step key {_key_text(sub_key)!r} must have the form "(index, name)"',
+                    SourceSpan.of(file, sub_key),
+                )
+                continue
+            steps.append((parsed, _sidecar(sub_value, file, diags)))
+
+    return WicSidecar(steps=tuple(steps), entries=tuple(entries), span=span)
+
+
+def _step_key(text: str) -> StepKey | None:
+    """Normalise a `"(1, name)"` sidecar key, or None if it is malformed."""
+    match = _WIC_STEP_KEY.match(text)
+    if match is None:
+        return None
+    return StepKey(int(match.group(1)), match.group(2))
+
+
+# --------------------------------------------------------------------------
+# Leaves
+# --------------------------------------------------------------------------
+
+
+def _literal(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Any:
+    """Materialise an `!ii` payload, which may be a scalar, mapping, or sequence.
+
+    A custom tag suppresses YAML's own type resolution, so `!ii 5` arrives as
+    the text "5". Re-resolving it here reproduces `inlineinput_constructor`
+    exactly, which matters: the two must agree or the specification would
+    quietly change what existing documents mean.
+    """
+    if not isinstance(node, yaml.nodes.ScalarNode):
+        return _opaque(node, file, diags)
+    if node.value == '':
+        return ''
+    try:
+        return yaml.safe_load(node.value)
+    except yaml.YAMLError:
+        # Not a primitive; the literal text is the honest interpretation.
+        return node.value
+
+
+def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
+    """Materialise a node Sophios does not interpret, preserving it verbatim.
+
+    Custom wic tags are still recognised inside otherwise-opaque content so
+    that an edge reference buried in passthrough is not silently flattened to
+    a plain string.
+    """
+    match node:
+        case yaml.nodes.ScalarNode():
+            if node.tag in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
+                return _input_value(node, file, diags)
+            return _tagged_scalar(node)
+        case yaml.nodes.SequenceNode():
+            return [_opaque(item, file, diags) for item in node.value]
+        case yaml.nodes.MappingNode():
+            return {_key_text(k): _opaque(v, file, diags) for k, v in node.value}
+        case _:
+            diags.error(Code.UNKNOWN_TAG, f'unsupported node {_kind(node)}', SourceSpan.of(file, node))
+            return None
+
+
+def _tagged_scalar(node: yaml.nodes.ScalarNode) -> Any:
+    """Convert a resolved scalar node to its Python value."""
+    convert = _SCALAR_TAGS.get(node.tag)
+    if convert is None:
+        return node.value
+    try:
+        return convert(node.value)
+    except ValueError:
+        # The resolver claimed a type the text cannot actually produce; the raw
+        # text is the honest fallback.
+        return node.value
+
+
+def _scalar(node: yaml.nodes.Node) -> Any:
+    """Return a scalar node's value, or None for any other node kind."""
+    return _tagged_scalar(node) if isinstance(node, yaml.nodes.ScalarNode) else None
+
+
+def _key_text(node: yaml.nodes.Node) -> str:
+    """Return a mapping key as text."""
+    return str(node.value)
+
+
+def _kind(node: yaml.nodes.Node) -> str:
+    """Describe a node's kind for a diagnostic message."""
+    match node:
+        case yaml.nodes.ScalarNode() if node.tag == 'tag:yaml.org,2002:null':
+            return 'nothing'
+        case yaml.nodes.ScalarNode():
+            return 'a scalar'
+        case yaml.nodes.SequenceNode():
+            return 'a sequence'
+        case yaml.nodes.MappingNode():
+            return 'a mapping'
+        case _:
+            return 'an unsupported node'
+
+
+def _yaml_error_message(exc: yaml.YAMLError) -> str:
+    """Extract a single-line message from a PyYAML error."""
+    problem = getattr(exc, 'problem', None)
+    return str(problem) if problem else str(exc).splitlines()[0]
+
+
+def _yaml_error_span(file: str, exc: yaml.YAMLError, fallback: SourceSpan) -> SourceSpan:
+    """Locate a PyYAML error, falling back to the whole document."""
+    mark = getattr(exc, 'problem_mark', None)
+    if mark is None:
+        return fallback
+    return SourceSpan(file, mark.line + 1, mark.column + 1, mark.line + 1, mark.column + 1)

--- a/src/sophios/lang/spans.py
+++ b/src/sophios/lang/spans.py
@@ -1,0 +1,44 @@
+"""Source positions for `.wic` documents.
+
+Every AST node carries a span so a diagnostic can name a file, a line, and a
+column instead of describing a schema violation somewhere in a generated
+document. See design_docs/core-refactor-design.md, Spec 1.
+"""
+from dataclasses import dataclass
+from typing import Self
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSpan:
+    """A half-open region of a source file, with 1-based line and column.
+
+    PyYAML reports 0-based marks; conversion happens once, here, so that every
+    consumer sees the same convention an editor would display.
+    """
+
+    file: str
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+
+    @classmethod
+    def from_marks(cls, file: str, start: yaml.Mark, end: yaml.Mark) -> Self:
+        """Build a span from a PyYAML node's start and end marks."""
+        return cls(
+            file=file,
+            start_line=start.line + 1,
+            start_column=start.column + 1,
+            end_line=end.line + 1,
+            end_column=end.column + 1,
+        )
+
+    @classmethod
+    def of(cls, file: str, node: yaml.nodes.Node) -> Self:
+        """Build a span covering a composed YAML node."""
+        return cls.from_marks(file, node.start_mark, node.end_mark)
+
+    def __str__(self) -> str:
+        return f'{self.file}:{self.start_line}:{self.start_column}'

--- a/src/sophios/lang/spans.py
+++ b/src/sophios/lang/spans.py
@@ -1,4 +1,4 @@
-"""Source positions for `.wic` documents.
+"""Source positions for Sophios documents.
 
 Every AST node carries a span so a diagnostic can name a file, a line, and a
 column instead of describing a schema violation somewhere in a generated

--- a/src/sophios/utils_yaml.py
+++ b/src/sophios/utils_yaml.py
@@ -11,12 +11,14 @@ import yaml
 TAG_ANCHOR = '!&'
 TAG_ALIAS = '!*'
 TAG_INLINE_INPUT = '!ii'
+TAG_RAW_CWL = '!cwl'
 
 # The dict keys the tags above are rewritten to by the constructors below.
 # (Deliberately different from the tags themselves; see NOTE above.)
 KEY_ANCHOR = 'wic_anchor'
 KEY_ALIAS = 'wic_alias'
 KEY_INLINE_INPUT = 'wic_inline_input'
+KEY_RAW_CWL = 'wic_raw_cwl'
 
 
 def anchor_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> dict[str, Any]:
@@ -55,10 +57,22 @@ def inlineinput_constructor(loader: yaml.SafeLoader, node: yaml.nodes.Node) -> d
     return {KEY_INLINE_INPUT: val}
 
 
+def rawcwl_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> dict[str, Any]:
+    """PyYAML constructor for the custom `!cwl` (raw CWL reference) tag.
+
+    The expression is opaque to Sophios and handed to CWL unresolved; like the
+    other three constructors, the tag desugars to a key so the loader stays
+    idempotent (see NOTE above).
+    """
+    val = loader.construct_scalar(node)
+    return {KEY_RAW_CWL: val}
+
+
 def wic_loader() -> type[yaml.SafeLoader]:
-    """Return a `yaml.SafeLoader` with the `!&`, `!*`, and `!ii` wic tags registered."""
+    """Return a `yaml.SafeLoader` with the `!&`, `!*`, `!ii`, and `!cwl` tags registered."""
     loader = yaml.SafeLoader
     loader.add_constructor(TAG_ANCHOR, anchor_constructor)
     loader.add_constructor(TAG_ALIAS, alias_constructor)
     loader.add_constructor(TAG_INLINE_INPUT, inlineinput_constructor)
+    loader.add_constructor(TAG_RAW_CWL, rawcwl_constructor)
     return loader

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -18,7 +18,7 @@ from typing import Any, get_args
 
 import pytest
 import yaml
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, example, given, settings
 from hypothesis import strategies as st
 
 from sophios.lang import (
@@ -182,7 +182,7 @@ def _resolvable(span: SourceSpan, text: str) -> bool:
     lines = text.splitlines() or ['']
     if not 1 <= span.start_line <= len(lines):
         return False
-    return 1 <= span.start_column <= len(lines[span.start_line - 1]) + 1
+    return bool(1 <= span.start_column <= len(lines[span.start_line - 1]) + 1)
 
 
 # --------------------------------------------------------------------------
@@ -339,7 +339,9 @@ def test_sequence_and_mapping_steps_agree() -> None:
     as_seq = parse('steps:\n- id: touch\n  in:\n    f: !ii x\n', 's.wic').document
     assert as_map is not None and as_seq is not None
     assert [s.id for s in as_map.steps] == [s.id for s in as_seq.steps] == ['touch']
-    assert as_map.steps[0].inputs[0][1].value == as_seq.steps[0].inputs[0][1].value  # type: ignore[union-attr]
+    from_map, from_seq = as_map.steps[0].inputs[0][1], as_seq.steps[0].inputs[0][1]
+    assert isinstance(from_map, InlineLiteral) and isinstance(from_seq, InlineLiteral)
+    assert from_map.value == from_seq.value
 
 
 @pytest.mark.fast
@@ -419,19 +421,22 @@ def test_python_api_emits_documents_this_parser_accepts() -> None:
 
 
 @pytest.mark.fast
-def test_unknown_tag_in_input_position_is_reported() -> None:
-    """`!foo bar` as an input value is a diagnostic, not UnresolvedName('bar')."""
-    result = parse('steps:\n- id: s\n  in:\n    a: !foo bar\n', 'x.wic')
-    assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics)
+@pytest.mark.parametrize('source', [
+    'steps:\n- id: s\n  in:\n    a: !foo bar\n',
+    'top: !foo bar\n',
+    'top: !foo {a: 1}\n',
+    'top: !foo [1, 2]\n',
+    'steps:\n- id: s\n  in:\n    a: !foo {wic_anchor: x}\n',
+], ids=['input-pos', 'scalar', 'mapping', 'sequence', 'over-desugared'])
+def test_unknown_tags_report_wic009(source: str) -> None:
+    """The code contract: an unknown tag reports wic009, in every position.
+
+    *Detection* is the adversarial property's job (with @example pins for
+    determinism); this asserts only the stable code the reference documents.
+    """
+    result = parse(source, 'x.wic')
+    assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics), source
     assert not result.ok
-
-
-@pytest.mark.fast
-def test_unknown_tag_in_passthrough_is_reported() -> None:
-    """The tag is not silently dropped from passthrough content either."""
-    for source in ('top: !foo bar\n', 'top: !foo {a: 1}\n', 'top: !foo [1, 2]\n'):
-        result = parse(source, 'x.wic')
-        assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics), source
 
 
 @pytest.mark.fast
@@ -526,24 +531,18 @@ def test_the_loader_accepts_every_owned_tag() -> None:
 
 
 @pytest.mark.fast
-def test_a_tag_wrapping_a_desugared_form_is_reported() -> None:
-    """P2: `!foo {wic_anchor: x}` is an unknown tag, not a silent anchor.
+@pytest.mark.parametrize('source', ['top: &a [*a]\n',
+                                    'steps: &a\n- id: s\n  in:\n    x: *a\n',
+                                    'wic: &w\n  steps: *w\n'],
+                         ids=['passthrough', 'steps', 'sidecar'])
+def test_alias_cycles_are_reported(source: str) -> None:
+    """The contract: a cycle is a diagnosed error, never a quiet success.
 
-    The desugared probe used to run before the tag check, so input position
-    and passthrough disagreed with each other as well as with the loader.
+    Totality (no raise) is the adversarial property's job, with these shapes
+    pinned on it as @example; this asserts the report the reference promises.
     """
-    result = parse('steps:\n- id: s\n  in:\n    a: !foo {wic_anchor: x}\n', 'x.wic')
-    assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics)
-
-
-@pytest.mark.fast
-def test_p04_alias_cycles_are_reported_not_raised() -> None:
-    """P3: a self-containing alias is a diagnostic, not a RecursionError."""
-    for source in ('top: &a [*a]\n',
-                   'steps: &a\n- id: s\n  in:\n    x: *a\n',
-                   'wic: &w\n  steps: *w\n'):
-        result = parse(source, 'cycle.wic')  # must not raise
-        assert not result.ok, source
+    result = parse(source, 'cycle.wic')
+    assert not result.ok, source
 
 
 @pytest.mark.fast
@@ -575,24 +574,6 @@ def test_out_values_are_never_silently_dropped() -> None:
         binding = result.document.steps[0].outputs[0]
         assert binding.edge_def is not None and binding.edge_def.name == 'e'
 
-
-@pytest.mark.fast
-def test_every_problem_is_reported_exactly_once() -> None:
-    """N1: one problem, one diagnostic — never the same report twice.
-
-    Several parse paths legitimately visit the same node; the review measured
-    identical (code, span, message) pairs reported 2-3 times on every new
-    diagnostic path.
-    """
-    cases = ('steps:\n- id: s\n  in:\n    a: !foo [1]\n',
-             'steps:\n- id: s\n  in:\n    a: !foo {x: 1}\n',
-             'steps:\n- ? [a, b]\n  : {}\n',
-             'steps:\n  s:\n    in:\n      ? [a, b]\n      : x\n',
-             'wic:\n  steps:\n    nope:\n      x: 1\n')
-    for source in cases:
-        result = parse(source, 'once.wic')
-        reports = [(d.severity, d.code, d.message, d.span) for d in result.diagnostics]
-        assert len(reports) == len(set(reports)), f'duplicate diagnostics for {source!r}: {reports}'
 
 # --------------------------------------------------------------------------
 # Adversarial structure — the space the review proved the fuzzer never reached
@@ -649,15 +630,31 @@ def adversarial_yaml(draw: st.DrawFn) -> str:
 
 @pytest.mark.fast
 @given(adversarial_yaml())
+# Deterministic pins: Hypothesis is randomised and its failure database does
+# not travel to CI, so every counterexample this property has caught (or was
+# built to catch) is an @example — same coverage, no separate test functions.
+@example('top: &a [*a]\n')                                # alias cycle
+@example('steps: &a\n- id: s\n  in:\n    x: *a\n')        # cycle via steps
+@example('wic: &w\n  steps: *w\n')                        # cycle via sidecar
+@example('_: !& []\n')                                    # CE-06: name tag on a collection
+@example('_: !foo bar\n')                                 # unknown tag, passthrough
+@example('a: !cwl b\n')                                   # the once-missing loader constructor
+@example('_: !ii {k: v}\n')                               # collection literal, single wrap
 @FAST
 def test_p04_parsing_is_total_for_adversarial_structure(text: str) -> None:
     """P04, the half the review proved missing: totality over real YAML
     structure — aliases, cycles, unknown tags, nesting — not just over text.
 
-    Never raises, and never accepts silently what the loader rejects.
+    Never raises; never accepts silently what the loader rejects; and never
+    reports the same problem twice — several parse paths legitimately visit
+    the same node, and duplicate (code, span, message) reports were a
+    measured regression once already.
     """
     result = parse(text, 'adversarial.wic')  # must not raise
     assert result.document is not None or len(result.diagnostics) > 0
+
+    reports = [(d.severity, d.code, d.message, d.span) for d in result.diagnostics]
+    assert len(reports) == len(set(reports)), f'duplicate diagnostics: {reports}'
 
     if result.ok and result.document is not None:
         yaml.load(text, Loader=wic_loader())  # agreement holds here too

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -12,6 +12,7 @@ Properties covered:
 
 See design_docs/core-refactor-design.md, Spec 1.
 """
+import time
 from pathlib import Path
 from typing import Any, get_args
 
@@ -22,6 +23,8 @@ from hypothesis import strategies as st
 
 from sophios.lang import (
     Code,
+    Diagnostic,
+    Diagnostics,
     Document,
     EdgeDef,
     EdgeRef,
@@ -56,34 +59,85 @@ scalars = st.one_of(
 
 
 @st.composite
-def input_lines(draw: st.DrawFn) -> str:
-    """One `in:` binding, in any of the forms the language admits."""
+def input_lines(draw: st.DrawFn, indent: str = '      ') -> str:
+    """One `in:` binding, in any of the forms the language admits.
+
+    Both spellings of each construct are generated — the tagged form people
+    write and the desugared form tooling emits — so the properties quantify
+    over the language, not over the half of it the tests happened to spell.
+    """
     name = draw(identifiers)
-    form = draw(st.sampled_from(['ii', 'anchor', 'alias', 'cwl', 'bare']))
+    form = draw(st.sampled_from(['ii', 'anchor', 'alias', 'cwl', 'bare',
+                                 'ii_desugared', 'anchor_desugared', 'alias_desugared', 'cwl_desugared']))
     match form:
         case 'ii':
-            return f'      {name}: !ii {draw(scalars)}'
+            return f'{indent}{name}: !ii {draw(scalars)}'
         case 'anchor':
-            return f'      {name}: !& {draw(identifiers)}'
+            return f'{indent}{name}: !& {draw(identifiers)}'
         case 'alias':
-            return f'      {name}: !* {draw(identifiers)}'
+            return f'{indent}{name}: !* {draw(identifiers)}'
         case 'cwl':
-            return f'      {name}: !cwl {draw(identifiers)}/{draw(identifiers)}'
+            return f'{indent}{name}: !cwl {draw(identifiers)}/{draw(identifiers)}'
+        case 'ii_desugared':
+            return f'{indent}{name}: {{wic_inline_input: {draw(identifiers)}}}'
+        case 'anchor_desugared':
+            return f'{indent}{name}: {{wic_anchor: {draw(identifiers)}}}'
+        case 'alias_desugared':
+            return f'{indent}{name}: {{wic_alias: {draw(identifiers)}}}'
+        case 'cwl_desugared':
+            return f'{indent}{name}: {{wic_raw_cwl: {draw(identifiers)}/{draw(identifiers)}}}'
         case _:
-            return f'      {name}: {draw(identifiers)}'
+            return f'{indent}{name}: {draw(identifiers)}'
+
+
+@st.composite
+def _out_lines(draw: st.DrawFn, indent: str) -> list[str]:
+    """An `out:` block: bare names and `!&`-bound names, in both spellings."""
+    lines = [f'{indent}out:']
+    for _ in range(draw(st.integers(min_value=1, max_value=2))):
+        name = draw(identifiers)
+        match draw(st.sampled_from(['bare', 'edge', 'edge_desugared'])):
+            case 'bare':
+                lines.append(f'{indent}- {name}')
+            case 'edge':
+                lines.append(f'{indent}- {name}: !& {draw(identifiers)}')
+            case _:
+                lines.append(f'{indent}- {name}: {{wic_anchor: {draw(identifiers)}}}')
+    return lines
 
 
 @st.composite
 def documents(draw: st.DrawFn) -> str:
-    """A syntactically well-formed Sophios document, in mapping-form steps."""
+    """A syntactically well-formed Sophios document.
+
+    Generates both step surface forms (mapping and sequence-with-id), inputs
+    in every admitted spelling, `out:` blocks, and nested `wic: steps:`
+    sidecars. Review of this PR found the previous generator quantified over
+    mapping-form `in:`-only documents, leaving outputs, sequence steps, and
+    depth-2 sidecars structurally invisible to every property fed by it.
+    """
     lines = ['steps:']
-    for _ in range(draw(st.integers(min_value=1, max_value=4))):
-        lines.append(f'  {draw(identifiers)}:')
-        lines.append('    in:')
+    sequence_form = draw(st.booleans())
+    names = draw(st.lists(identifiers, min_size=1, max_size=4, unique=True))
+    for step in names:
+        if sequence_form:
+            lines.append(f'- id: {step}')
+            body_indent = '  '
+        else:
+            lines.append(f'  {step}:')
+            body_indent = '    '
+        lines.append(f'{body_indent}in:')
         for _ in range(draw(st.integers(min_value=1, max_value=3))):
-            lines.append(draw(input_lines()))
+            lines.append(draw(input_lines(indent=body_indent + '  ')))
+        if draw(st.booleans()):
+            lines.extend(draw(_out_lines(body_indent)))
     if draw(st.booleans()):
         lines += ['wic:', '  graphviz:', f'    label: {draw(identifiers)}']
+        if draw(st.booleans()):
+            # A nested sidecar: the (index, name) key wraps a wic: block.
+            lines += ['  steps:', f'    (1, {names[0]}):', '      wic:',
+                      '        steps:', f'          (1, {draw(identifiers)}):',
+                      f'            label: {draw(identifiers)}']
     return '\n'.join(lines) + '\n'
 
 
@@ -314,7 +368,9 @@ def test_malformed_yaml_reports_a_located_diagnostic() -> None:
     result = parse('steps:\n  - [unclosed\n', 'bad.wic')
     assert result.document is None
     assert len(result.diagnostics) == 1
-    assert result.diagnostics[0].span.start_line >= 1
+    first: Diagnostic = result.diagnostics[0]
+    # pylint: disable-next=no-member  # pylint picks the slice overload for [0]
+    assert first.span is not None and first.span.start_line >= 1
 
 
 @pytest.mark.fast
@@ -427,6 +483,113 @@ def test_untagged_collection_inputs_are_inline_literals() -> None:
 def test_diagnostics_slices_are_diagnostics() -> None:
     """Slicing honours the Sequence contract instead of degrading to list."""
     result = parse('steps:\n- id: s\n  in:\n    a: !foo x\n    b: !bar y\n', 'x.wic')
-    from sophios.lang import Diagnostics
     assert isinstance(result.diagnostics[0:1], Diagnostics)
     assert len(result.diagnostics[0:1]) == 1
+
+# --------------------------------------------------------------------------
+# Offline review round two (P1, P2, P3, P5, N1)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_sidecar_nesting_is_normalised_at_every_depth() -> None:
+    """P1: `(index, name)` keys are StepKeys at depth two, not opaque strings.
+
+    The child sidecar arrives wrapped in a `wic:` key on the surface; the
+    parser descends through it, or `StepKey`'s "nothing downstream should
+    ever parse that string again" is false at every depth past the first.
+    """
+    result = parse(
+        'wic:\n  steps:\n    (1, outer):\n      wic:\n        steps:\n'
+        '          (1, inner):\n            wic:\n              steps:\n'
+        '                (1, innermost):\n                  x: 1\n',
+        'nested.wic')
+    assert result.ok and result.document is not None and result.document.sidecar is not None
+
+    level1 = result.document.sidecar.steps[0]
+    assert (level1[0].index, level1[0].name) == (1, 'outer')
+    level2 = level1[1].steps[0]
+    assert (level2[0].index, level2[0].name) == (1, 'inner')
+    level3 = level2[1].steps[0]
+    assert (level3[0].index, level3[0].name) == (1, 'innermost')
+
+
+@pytest.mark.fast
+def test_the_loader_accepts_every_owned_tag() -> None:
+    """P2: `!cwl` is registered with the loader like its three siblings.
+
+    The agreement property below quantifies over this; the targeted case is
+    pinned so a regression names itself instead of surfacing as a fuzz flake.
+    """
+    loaded = yaml.load('a: !cwl step/out\n', Loader=wic_loader())
+    assert loaded == {'a': {'wic_raw_cwl': 'step/out'}}
+
+
+@pytest.mark.fast
+def test_a_tag_wrapping_a_desugared_form_is_reported() -> None:
+    """P2: `!foo {wic_anchor: x}` is an unknown tag, not a silent anchor.
+
+    The desugared probe used to run before the tag check, so input position
+    and passthrough disagreed with each other as well as with the loader.
+    """
+    result = parse('steps:\n- id: s\n  in:\n    a: !foo {wic_anchor: x}\n', 'x.wic')
+    assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics)
+
+
+@pytest.mark.fast
+def test_p04_alias_cycles_are_reported_not_raised() -> None:
+    """P3: a self-containing alias is a diagnostic, not a RecursionError."""
+    for source in ('top: &a [*a]\n',
+                   'steps: &a\n- id: s\n  in:\n    x: *a\n',
+                   'wic: &w\n  steps: *w\n'):
+        result = parse(source, 'cycle.wic')  # must not raise
+        assert not result.ok, source
+
+
+@pytest.mark.fast
+def test_p04_alias_expansion_is_bounded() -> None:
+    """P3: a widening alias chain is cut off by budget, quickly, once."""
+    laughs = 'a0: &a0 [x, x, x, x, x, x, x, x, x]\n'
+    for i in range(1, 8):
+        refs = ', '.join([f'*a{i-1}'] * 9)
+        laughs += f'a{i}: &a{i} [{refs}]\n'
+
+    started = time.perf_counter()
+    result = parse(laughs, 'laughs.wic')  # must not raise or hang
+    assert time.perf_counter() - started < 5.0
+    assert not result.ok
+    assert any(d.code is Code.RECURSIVE_ALIAS for d in result.diagnostics)
+
+
+@pytest.mark.fast
+def test_out_values_are_never_silently_dropped() -> None:
+    """P5: a non-!& out value is reported; both edge spellings are honoured."""
+    dropped = parse('steps:\n- id: s\n  out:\n  - file: something\n', 'x.wic')
+    assert not dropped.ok
+    assert any('file' in d.message for d in dropped.diagnostics)
+
+    tagged = parse('steps:\n- id: s\n  out:\n  - file: !& e\n', 'x.wic')
+    desugared = parse('steps:\n- id: s\n  out:\n  - file: {wic_anchor: e}\n', 'x.wic')
+    for result in (tagged, desugared):
+        assert result.ok and result.document is not None
+        binding = result.document.steps[0].outputs[0]
+        assert binding.edge_def is not None and binding.edge_def.name == 'e'
+
+
+@pytest.mark.fast
+def test_every_problem_is_reported_exactly_once() -> None:
+    """N1: one problem, one diagnostic — never the same report twice.
+
+    Several parse paths legitimately visit the same node; the review measured
+    identical (code, span, message) pairs reported 2-3 times on every new
+    diagnostic path.
+    """
+    cases = ('steps:\n- id: s\n  in:\n    a: !foo [1]\n',
+             'steps:\n- id: s\n  in:\n    a: !foo {x: 1}\n',
+             'steps:\n- ? [a, b]\n  : {}\n',
+             'steps:\n  s:\n    in:\n      ? [a, b]\n      : x\n',
+             'wic:\n  steps:\n    nope:\n      x: 1\n')
+    for source in cases:
+        result = parse(source, 'once.wic')
+        reports = [(d.severity, d.code, d.message, d.span) for d in result.diagnostics]
+        assert len(reports) == len(set(reports)), f'duplicate diagnostics for {source!r}: {reports}'

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -59,7 +59,7 @@ scalars = st.one_of(
 
 
 @st.composite
-def input_lines(draw: st.DrawFn, indent: str = '      ') -> str:
+def input_lines(draw: st.DrawFn, indent: str = '      ') -> str:  # pylint: disable=too-many-return-statements
     """One `in:` binding, in any of the forms the language admits.
 
     Both spellings of each construct are generated — the tagged form people
@@ -593,3 +593,113 @@ def test_every_problem_is_reported_exactly_once() -> None:
         result = parse(source, 'once.wic')
         reports = [(d.severity, d.code, d.message, d.span) for d in result.diagnostics]
         assert len(reports) == len(set(reports)), f'duplicate diagnostics for {source!r}: {reports}'
+
+# --------------------------------------------------------------------------
+# Adversarial structure — the space the review proved the fuzzer never reached
+# --------------------------------------------------------------------------
+#
+# `st.text()` almost never forms valid YAML with aliases, so quantifying
+# totality over it left the entire anchor/alias class untested: cycles raised
+# RecursionError and widening chains exhausted memory while P04 stayed green.
+# These strategies generate *structured* YAML — anchors, aliases (including
+# self-referential ones), tags known and unknown, deep nesting — so the
+# property covers the inputs that actually break parsers.
+
+
+_tag_pool = st.sampled_from(['', '!ii ', '!& ', '!* ', '!cwl ', '!foo ', '!x '])
+
+
+@st.composite
+def adversarial_yaml(draw: st.DrawFn) -> str:
+    """Structured YAML text with anchors, aliases, tags, and real nesting."""
+    fragments = []
+    anchors: list[str] = []
+    for i in range(draw(st.integers(min_value=1, max_value=6))):
+        key = draw(identifiers)
+        shape = draw(st.sampled_from(['scalar', 'flow_list', 'flow_map', 'anchor', 'alias', 'self_ref', 'nested']))
+        tag = draw(_tag_pool)
+        match shape:
+            case 'scalar':
+                fragments.append(f'{key}: {tag}{draw(identifiers)}')
+            case 'flow_list':
+                items = ', '.join(draw(st.lists(identifiers, min_size=0, max_size=4)))
+                fragments.append(f'{key}: {tag}[{items}]')
+            case 'flow_map':
+                inner = draw(identifiers)
+                fragments.append(f'{key}: {tag}{{{inner}: {draw(identifiers)}}}')
+            case 'anchor':
+                anchors.append(f'a{i}')
+                fragments.append(f'{key}: &a{i} [{draw(identifiers)}]')
+            case 'alias' if anchors:
+                ref = draw(st.sampled_from(anchors))
+                repeats = ', '.join([f'*{ref}'] * draw(st.integers(min_value=1, max_value=6)))
+                anchors.append(f'a{i}')
+                fragments.append(f'{key}: &a{i} [{repeats}]')
+            case 'self_ref':
+                # A node that contains itself — legal YAML, lethal to naive walks.
+                fragments.append(f'{key}: &s{i} [x, *s{i}]')
+            case _:
+                depth = draw(st.integers(min_value=1, max_value=5))
+                nested = draw(identifiers)
+                for _ in range(depth):
+                    nested = f'{{n: {nested}}}'
+                fragments.append(f'{key}: {nested}')
+    return '\n'.join(fragments) + '\n'
+
+
+@pytest.mark.fast
+@given(adversarial_yaml())
+@FAST
+def test_p04_parsing_is_total_for_adversarial_structure(text: str) -> None:
+    """P04, the half the review proved missing: totality over real YAML
+    structure — aliases, cycles, unknown tags, nesting — not just over text.
+
+    Never raises, and never accepts silently what the loader rejects.
+    """
+    result = parse(text, 'adversarial.wic')  # must not raise
+    assert result.document is not None or len(result.diagnostics) > 0
+
+    if result.ok and result.document is not None:
+        yaml.load(text, Loader=wic_loader())  # agreement holds here too
+
+
+@pytest.mark.fast
+@given(_tag_pool, st.sampled_from(['scalar', 'flow_map']), st.data())
+@FAST
+def test_tag_decisions_agree_across_positions(tag: str, shape: str, data: st.DataObject) -> None:
+    """Input position and passthrough position make the same unknown-tag call.
+
+    The review found `!foo {wic_anchor: x}` reported in passthrough but
+    swallowed in input position — two paths, one language, two answers. This
+    pins the agreement for every tag and payload shape the generator makes.
+    """
+    payload = data.draw(identifiers) if shape == 'scalar' else f'{{{data.draw(identifiers)}: x}}'
+    value = f'{tag}{payload}'
+
+    in_position = parse(f'steps:\n- id: s\n  in:\n    a: {value}\n', 'pos.wic')
+    passthrough = parse(f'top: {value}\n', 'pos.wic')
+
+    reported_in = any(d.code is Code.UNKNOWN_TAG for d in in_position.diagnostics)
+    reported_through = any(d.code is Code.UNKNOWN_TAG for d in passthrough.diagnostics)
+    assert reported_in == reported_through, f'{value!r}: input={reported_in}, passthrough={reported_through}'
+
+
+@pytest.mark.fast
+def test_inline_literal_collections_wrap_exactly_once() -> None:
+    """`!ii {a: 1}` is one InlineLiteral around plain data, in both positions.
+
+    The passthrough walk wraps tagged collections and `_literal`'s caller
+    wraps too; without coordination the same node wrapped twice and the AST
+    carried InlineLiteral(InlineLiteral(...)).
+    """
+    in_position = parse('steps:\n- id: s\n  in:\n    a: !ii {k: v}\n', 'x.wic')
+    assert in_position.ok and in_position.document is not None
+    literal = in_position.document.steps[0].inputs[0][1]
+    assert isinstance(literal, InlineLiteral)
+    assert literal.value == {'k': 'v'}
+
+    passthrough = parse('top: !ii {k: v}\n', 'x.wic')
+    assert passthrough.ok and passthrough.document is not None
+    wrapped = dict(passthrough.document.passthrough)['top']
+    assert isinstance(wrapped, InlineLiteral)
+    assert wrapped.value == {'k': 'v'}

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -208,6 +208,46 @@ def test_corpus_is_not_empty() -> None:
     assert CORPUS, 'no corpus .wic files discovered'
 
 
+@pytest.mark.fast
+@given(
+    st.sampled_from([('!ii', 'wic_inline_input', InlineLiteral),
+                     ('!&', 'wic_anchor', EdgeDef),
+                     ('!*', 'wic_alias', EdgeRef),
+                     ('!cwl', 'wic_raw_cwl', RawCwlRef)]),
+    identifiers,
+)
+@FAST
+def test_surface_forms_are_equivalent(form: tuple[str, str, type], payload: str) -> None:
+    """Tagged and desugared spellings of a construct parse to the same node.
+
+    Humans write `!ii x`; the Python API emits `{wic_inline_input: x}`, because
+    a constructor that re-emitted its own tag would fire again on reload. Both
+    are the same language, so both must produce the same AST — otherwise the
+    two front-ends have quietly diverged.
+    """
+    tag, key, expected = form
+    tagged = parse(f'steps:\n- id: s\n  in:\n    f: {tag} {payload}\n', 'a.wic')
+    sugared = parse(f'steps:\n- id: s\n  in:\n    f:\n      {key}: {payload}\n', 'b.wic')
+    assert tagged.ok and sugared.ok
+    assert tagged.document is not None and sugared.document is not None
+
+    left = tagged.document.steps[0].inputs[0][1]
+    right = sugared.document.steps[0].inputs[0][1]
+    assert isinstance(left, expected) and isinstance(right, expected)
+    assert _payload(left) == _payload(right)
+
+
+def _payload(value: InputValue) -> Any:
+    """The carried value of an input node, whatever its form."""
+    match value:
+        case InlineLiteral():
+            return value.value
+        case RawCwlRef():
+            return value.expression
+        case EdgeDef() | EdgeRef() | UnresolvedName():
+            return value.name
+
+
 # --------------------------------------------------------------------------
 # Sanity checks (not acceptance evidence)
 # --------------------------------------------------------------------------
@@ -280,3 +320,32 @@ def test_passthrough_keys_are_retained() -> None:
     doc = parse('$namespaces:\n  edam: http://example\nsteps:\n  s: {}\n', 'p.wic').document
     assert doc is not None
     assert dict(doc.passthrough)['$namespaces'] == {'edam': 'http://example'}
+
+
+@pytest.mark.fast
+def test_python_api_emits_documents_this_parser_accepts() -> None:
+    """The Python API is a second front-end over the same language.
+
+    Whatever it emits must parse, or the two front-ends have diverged and the
+    language reference is describing something that does not exist. See
+    docs/wic_language_reference.md, section 6.
+    """
+    # Imported here: the API pulls in the whole compiler, which the syntax
+    # layer deliberately does not depend on.
+    # pylint: disable=import-outside-toplevel
+    from sophios.api.python.workflow import Step as ApiStep
+    from sophios.api.python.workflow import Workflow
+
+    from .test_python_api import _adapter
+
+    touch = ApiStep(clt_path=_adapter('touch'))
+    touch.inputs.filename = 'empty.txt'
+    workflow = Workflow([touch], 'adherence')
+
+    result = parse(workflow.to_wic_yaml(), 'api_emitted.wic')
+
+    assert result.ok, [str(d) for d in result.diagnostics]
+    assert result.document is not None
+    emitted = result.document.steps[0].input('filename')
+    assert isinstance(emitted, InlineLiteral)
+    assert emitted.value == 'empty.txt'

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -1,0 +1,282 @@
+"""Properties of the `.wic` syntax layer (CR-101).
+
+Acceptance here is property-based. The unit tests at the end are sanity checks
+on wiring and obvious errors; they are not evidence that the parser is correct.
+
+Properties covered:
+  P03  every AST node carries a resolvable source span
+  P04  parsing never raises; it returns an AST or diagnostics
+  P05  InputValue is closed — no value escapes the five forms
+  P06  every diagnostic span indexes real source text
+  P07  every corpus .wic parses
+
+See design_docs/core-refactor-design.md, Spec 1.
+"""
+from pathlib import Path
+from typing import Any, get_args
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from sophios.lang import (
+    Document,
+    EdgeDef,
+    EdgeRef,
+    InlineLiteral,
+    InputValue,
+    RawCwlRef,
+    Step,
+    UnresolvedName,
+    WicSidecar,
+    parse,
+)
+from sophios.lang.spans import SourceSpan
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORPUS_DIRS = (REPO_ROOT / 'docs' / 'tutorials', REPO_ROOT / 'examples')
+
+FAST = settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+CORPUS = sorted(p for d in CORPUS_DIRS if d.is_dir() for p in d.rglob('*.wic'))
+
+
+# --------------------------------------------------------------------------
+# Strategies
+# --------------------------------------------------------------------------
+
+identifiers = st.text('abcdefghijklmnopqrstuvwxyz_', min_size=1, max_size=8)
+scalars = st.one_of(
+    st.integers(min_value=-1000, max_value=1000),
+    st.booleans(),
+    st.text('abcXYZ 0123', min_size=0, max_size=10),
+)
+
+
+@st.composite
+def input_lines(draw: st.DrawFn) -> str:
+    """One `in:` binding, in any of the forms the language admits."""
+    name = draw(identifiers)
+    form = draw(st.sampled_from(['ii', 'anchor', 'alias', 'cwl', 'bare']))
+    match form:
+        case 'ii':
+            return f'      {name}: !ii {draw(scalars)}'
+        case 'anchor':
+            return f'      {name}: !& {draw(identifiers)}'
+        case 'alias':
+            return f'      {name}: !* {draw(identifiers)}'
+        case 'cwl':
+            return f'      {name}: !cwl {draw(identifiers)}/{draw(identifiers)}'
+        case _:
+            return f'      {name}: {draw(identifiers)}'
+
+
+@st.composite
+def documents(draw: st.DrawFn) -> str:
+    """A syntactically well-formed `.wic` document, in mapping-form steps."""
+    lines = ['steps:']
+    for _ in range(draw(st.integers(min_value=1, max_value=4))):
+        lines.append(f'  {draw(identifiers)}:')
+        lines.append('    in:')
+        for _ in range(draw(st.integers(min_value=1, max_value=3))):
+            lines.append(draw(input_lines()))
+    if draw(st.booleans()):
+        lines += ['wic:', '  graphviz:', f'    label: {draw(identifiers)}']
+    return '\n'.join(lines) + '\n'
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _spans(node: Any) -> list[SourceSpan]:
+    """Collect every span reachable from an AST node."""
+    found: list[SourceSpan] = []
+    match node:
+        case Document():
+            found += _opt(node.span)
+            for step in node.steps:
+                found += _spans(step)
+            if node.sidecar is not None:
+                found += _spans(node.sidecar)
+        case Step():
+            found += _opt(node.span)
+            for _, value in node.inputs:
+                found += _spans(value)
+            for binding in node.outputs:
+                found.append(binding.span)
+                if binding.edge_def is not None:
+                    found.append(binding.edge_def.span)
+        case WicSidecar():
+            found += _opt(node.span)
+            for _, child in node.steps:
+                found += _spans(child)
+        case InlineLiteral() | EdgeDef() | EdgeRef() | RawCwlRef() | UnresolvedName():
+            found.append(node.span)
+    return found
+
+
+def _opt(span: SourceSpan | None) -> list[SourceSpan]:
+    return [span] if span is not None else []
+
+
+def _resolvable(span: SourceSpan, text: str) -> bool:
+    """Whether a span points at a position that exists in the source."""
+    lines = text.splitlines() or ['']
+    if not 1 <= span.start_line <= len(lines):
+        return False
+    return 1 <= span.start_column <= len(lines[span.start_line - 1]) + 1
+
+
+# --------------------------------------------------------------------------
+# Properties
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@given(st.text(max_size=400))
+@FAST
+def test_p04_parsing_is_total_for_arbitrary_text(text: str) -> None:
+    """P04: parsing never raises, whatever it is handed."""
+    result = parse(text, 'fuzz.wic')
+    assert result.document is not None or len(result.diagnostics) > 0
+
+
+@pytest.mark.fast
+@given(documents())
+@FAST
+def test_p04_well_formed_documents_parse(source: str) -> None:
+    """P04: a syntactically valid document yields a document and no errors."""
+    result = parse(source, 'gen.wic')
+    assert result.ok, [str(d) for d in result.diagnostics]
+
+
+@pytest.mark.fast
+@given(documents())
+@FAST
+def test_p03_every_node_carries_a_resolvable_span(source: str) -> None:
+    """P03: every span in the tree points at real source."""
+    result = parse(source, 'gen.wic')
+    assert result.document is not None
+    spans = _spans(result.document)
+    assert spans, 'no spans collected; the walk is not reaching the tree'
+    for span in spans:
+        assert _resolvable(span, source), f'unresolvable span {span}'
+
+
+@pytest.mark.fast
+@given(documents())
+@FAST
+def test_p05_input_values_are_closed(source: str) -> None:
+    """P05: every input value is one of the five declared forms."""
+    permitted = get_args(InputValue)
+    result = parse(source, 'gen.wic')
+    assert result.document is not None
+    for step in result.document.steps:
+        for name, value in step.inputs:
+            assert isinstance(value, permitted), f'{name} produced {type(value).__name__}'
+
+
+@pytest.mark.fast
+@given(st.text(max_size=400))
+@FAST
+def test_p06_diagnostic_spans_index_real_source(text: str) -> None:
+    """P06: a diagnostic never points outside the document it describes."""
+    for diagnostic in parse(text, 'fuzz.wic').diagnostics:
+        assert diagnostic.span.file == 'fuzz.wic'
+        assert diagnostic.span.start_line >= 1
+        assert diagnostic.span.start_column >= 1
+        assert diagnostic.span.start_line <= max(len(text.splitlines()), 1) + 1
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('path', CORPUS, ids=lambda p: p.name)
+def test_p07_corpus_files_parse(path: Path) -> None:
+    """P07: every `.wic` in the repository corpus parses without error.
+
+    This is what makes "the specification accepts what exists today"
+    falsifiable rather than an aspiration.
+    """
+    source = path.read_text(encoding='utf-8')
+    result = parse(source, str(path))
+    assert result.ok, [str(d) for d in result.diagnostics]
+
+
+@pytest.mark.fast
+def test_corpus_is_not_empty() -> None:
+    """The corpus scan must find files, or P07 passes vacuously."""
+    assert CORPUS, 'no corpus .wic files discovered'
+
+
+# --------------------------------------------------------------------------
+# Sanity checks (not acceptance evidence)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_tags_map_to_their_forms() -> None:
+    """Each surface tag produces its corresponding AST node."""
+    source = (
+        'steps:\n  s:\n    in:\n'
+        '      a: !ii 5\n'
+        '      b: !& anchor_name\n'
+        '      c: !* anchor_name\n'
+        '      d: !cwl other/out\n'
+        '      e: plain\n'
+    )
+    document = parse(source, 't.wic').document
+    assert document is not None
+    step = document.steps[0]
+    literal = step.input('a')
+    assert isinstance(literal, InlineLiteral) and literal.value == 5
+    assert isinstance(step.input('b'), EdgeDef)
+    assert isinstance(step.input('c'), EdgeRef)
+    assert isinstance(step.input('d'), RawCwlRef)
+    assert isinstance(step.input('e'), UnresolvedName)
+
+
+@pytest.mark.fast
+def test_sequence_and_mapping_steps_agree() -> None:
+    """Both `steps:` surface forms produce the same AST shape."""
+    as_map = parse('steps:\n  touch:\n    in:\n      f: !ii x\n', 'm.wic').document
+    as_seq = parse('steps:\n- id: touch\n  in:\n    f: !ii x\n', 's.wic').document
+    assert as_map is not None and as_seq is not None
+    assert [s.id for s in as_map.steps] == [s.id for s in as_seq.steps] == ['touch']
+    assert as_map.steps[0].inputs[0][1].value == as_seq.steps[0].inputs[0][1].value  # type: ignore[union-attr]
+
+
+@pytest.mark.fast
+def test_wic_step_keys_are_normalised() -> None:
+    """`"(1, name)"` sidecar keys become structured, not strings."""
+    doc = parse('wic:\n  steps:\n    (1, alpha):\n      wic:\n        graphviz: {}\n', 'w.wic').document
+    assert doc is not None and doc.sidecar is not None
+    key, _ = doc.sidecar.steps[0]
+    assert (key.index, key.name) == (1, 'alpha')
+
+
+@pytest.mark.fast
+def test_bare_wic_is_an_empty_sidecar_not_an_error() -> None:
+    """A `wic:` key with nothing under it is well-formed.
+
+    This is the shape that used to crash the CLI with a raw traceback.
+    """
+    result = parse('wic:\nsteps:\n  s:\n    in:\n      a: !ii 1\n', 'b.wic')
+    assert result.ok, [str(d) for d in result.diagnostics]
+    assert result.document is not None and result.document.sidecar is not None
+
+
+@pytest.mark.fast
+def test_malformed_yaml_reports_a_located_diagnostic() -> None:
+    """Broken YAML yields a diagnostic with a position, not an exception."""
+    result = parse('steps:\n  - [unclosed\n', 'bad.wic')
+    assert result.document is None
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].span.start_line >= 1
+
+
+@pytest.mark.fast
+def test_passthrough_keys_are_retained() -> None:
+    """Top-level keys the language does not interpret survive parsing."""
+    doc = parse('$namespaces:\n  edam: http://example\nsteps:\n  s: {}\n', 'p.wic').document
+    assert doc is not None
+    assert dict(doc.passthrough)['$namespaces'] == {'edam': 'http://example'}

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -16,10 +16,12 @@ from pathlib import Path
 from typing import Any, get_args
 
 import pytest
+import yaml
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from sophios.lang import (
+    Code,
     Document,
     EdgeDef,
     EdgeRef,
@@ -32,6 +34,7 @@ from sophios.lang import (
     parse,
 )
 from sophios.lang.spans import SourceSpan
+from sophios.utils_yaml import wic_loader
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CORPUS_DIRS = (REPO_ROOT / 'docs' / 'tutorials', REPO_ROOT / 'examples')
@@ -349,3 +352,81 @@ def test_python_api_emits_documents_this_parser_accepts() -> None:
     emitted = result.document.steps[0].input('filename')
     assert isinstance(emitted, InlineLiteral)
     assert emitted.value == 'empty.txt'
+
+# --------------------------------------------------------------------------
+# The parser is never more permissive than the loader (PR #382 review)
+# --------------------------------------------------------------------------
+#
+# The loader rejects unknown tags with ConstructorError; a syntax layer that
+# silently accepted them would specify a superset of the language. Both
+# escapes the review found are pinned, plus the agreement property.
+
+
+@pytest.mark.fast
+def test_unknown_tag_in_input_position_is_reported() -> None:
+    """`!foo bar` as an input value is a diagnostic, not UnresolvedName('bar')."""
+    result = parse('steps:\n- id: s\n  in:\n    a: !foo bar\n', 'x.wic')
+    assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics)
+    assert not result.ok
+
+
+@pytest.mark.fast
+def test_unknown_tag_in_passthrough_is_reported() -> None:
+    """The tag is not silently dropped from passthrough content either."""
+    for source in ('top: !foo bar\n', 'top: !foo {a: 1}\n', 'top: !foo [1, 2]\n'):
+        result = parse(source, 'x.wic')
+        assert any(d.code is Code.UNKNOWN_TAG for d in result.diagnostics), source
+
+
+@pytest.mark.fast
+@given(st.text('abcdefghijklmnopqrstuvwxyz!&*i {}[]:#-', max_size=120))
+@FAST
+def test_parser_is_not_more_permissive_than_the_loader(text: str) -> None:
+    """Any document the parser accepts without diagnostics, the loader loads.
+
+    The reverse is allowed — the parser recovers where the loader raises — but
+    this direction is the specification's half of the bargain.
+    """
+    result = parse(text, 'agree.wic')
+    if result.ok and result.document is not None:
+        yaml.load(text, Loader=wic_loader())  # must not raise
+
+
+@pytest.mark.fast
+@given(st.sampled_from(['010', '0x1A', '2020-01-01', '.inf', '12:30', 'true', 'null', '3.14', 'plain']))
+def test_passthrough_scalars_resolve_exactly_as_the_loader(text: str) -> None:
+    """Scalar resolution is delegated to PyYAML, not re-implemented.
+
+    A hand-written table diverged on every one of these; delegation makes the
+    divergence structurally impossible.
+    """
+    result = parse(f'top:\n  k: {text}\n', 'x.wic')
+    assert result.document is not None
+    parsed = dict(result.document.passthrough)['top']['k']
+    assert parsed == yaml.safe_load(text)
+
+
+@pytest.mark.fast
+def test_collection_keys_are_reported_not_stringified() -> None:
+    """`? [a, b]` as a step key is a diagnostic, not a repr of node objects."""
+    result = parse('steps:\n  ? [a, b]\n  : {}\n', 'x.wic')
+    assert any(d.code is Code.EXPECTED_SCALAR for d in result.diagnostics)
+
+
+@pytest.mark.fast
+def test_untagged_collection_inputs_are_inline_literals() -> None:
+    """An untagged mapping in input position is `!ii` by definition (§4.1)."""
+    result = parse('steps:\n- id: s\n  in:\n    a: {some: mapping}\n', 'x.wic')
+    assert result.ok and result.document is not None
+    value = result.document.steps[0].inputs[0][1]
+    assert isinstance(value, InlineLiteral)
+    assert value.value == {'some': 'mapping'}
+
+
+@pytest.mark.fast
+def test_diagnostics_slices_are_diagnostics() -> None:
+    """Slicing honours the Sequence contract instead of degrading to list."""
+    result = parse('steps:\n- id: s\n  in:\n    a: !foo x\n    b: !bar y\n', 'x.wic')
+    from sophios.lang import Diagnostics
+    assert isinstance(result.diagnostics[0:1], Diagnostics)
+    assert len(result.diagnostics[0:1]) == 1

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -1,4 +1,4 @@
-"""Properties of the `.wic` syntax layer (CR-101).
+"""Properties of the Sophios syntax layer (CR-101).
 
 Acceptance here is property-based. The unit tests at the end are sanity checks
 on wiring and obvious errors; they are not evidence that the parser is correct.
@@ -8,7 +8,7 @@ Properties covered:
   P04  parsing never raises; it returns an AST or diagnostics
   P05  InputValue is closed — no value escapes the five forms
   P06  every diagnostic span indexes real source text
-  P07  every corpus .wic parses
+  P07  every corpus document parses
 
 See design_docs/core-refactor-design.md, Spec 1.
 """
@@ -72,7 +72,7 @@ def input_lines(draw: st.DrawFn) -> str:
 
 @st.composite
 def documents(draw: st.DrawFn) -> str:
-    """A syntactically well-formed `.wic` document, in mapping-form steps."""
+    """A syntactically well-formed Sophios document, in mapping-form steps."""
     lines = ['steps:']
     for _ in range(draw(st.integers(min_value=1, max_value=4))):
         lines.append(f'  {draw(identifiers)}:')
@@ -328,7 +328,7 @@ def test_python_api_emits_documents_this_parser_accepts() -> None:
 
     Whatever it emits must parse, or the two front-ends have diverged and the
     language reference is describing something that does not exist. See
-    docs/wic_language_reference.md, section 6.
+    docs/sophios_language_reference.md, section 6.
     """
     # Imported here: the API pulls in the whole compiler, which the syntax
     # layer deliberately does not depend on.


### PR DESCRIPTION
Adds sophios.lang — a typed, frozen AST and a parser that composes YAML rather than loading it, so diagnostics can name a file, line, and column instead of reporting a schema violation somewhere in a generated document; parsing is total, returning an AST or diagnostics for any input, and the five input forms (!ii, !&, !*, the new !cwl, and bare names) are a closed union. It also adds docs/wic_language_reference.md, the human-readable definition the parser is meant to agree with, whose §6 turned out to matter most: Sophios has two front-ends emitting the same language and they had silently diverged, because the Python API writes the desugared spelling ({wic_inline_input: x}) while the parser understood only the tagged one — so API-written and hand-written .wic parsed to different ASTs. 

Fixing that surfaced two further bugs in the new code: str(_scalar(node) or '') destroyed falsy values, so an edge named false or a step id: 0 silently became empty, and edge names were being type-resolved when they are identifiers. The tagged and desugared spellings are now paired dispatch tables, so adding a construct means adding one row to each and the
equivalence is visible in the source rather than only asserted in prose. wic_raw_cwl is added as the desugared key for !cwl, which had no machine-emittable form. The syntax layer is deliberately environment-independent: resolution and type checking remain separate concerns, so a well-formed document that fails to resolve without theright plugins installed is not a language error.