### PR TITLE
Spec 1: pin the leak boundary against the real compiler

### DIFF
--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -58,11 +58,43 @@ point of this document:
 |---|---|---|
 | **Sophios-owned** | Consumes it; never appears in the output | `!ii`, `!&`, `!*`, `!cwl`, the `wic:` block |
 | **Interpreted CWL** | Reads it *and acts on it* | `scatter`, `scatterMethod`, `when`, inline `run` |
-| **Passthrough CWL** | Copies it out unchanged | `$namespaces`, `$schemas`, `requirements`, `hints`, everything else |
+| **Compiler-owned** | Writes or extends it at the workflow level¹ | `class`, `cwlVersion`, `inputs`, `outputs`, `requirements`, `$namespaces`, `$schemas` |
+| **Passthrough CWL** | Copies it out unchanged | `hints`, `label`, `doc`, everything else |
 
-The interpreted set is closed and listed in §4.3. **Anything not in it is
-passthrough, by definition.** That rule is what makes the leak a contract
-rather than a surprise.
+The interpreted set is closed and listed in §4.3. **Anything not interpreted
+and not compiler-owned is passthrough, by definition.** That rule is what makes
+the leak a contract rather than a surprise.
+
+¹ The compiler-owned row exists because "unchanged" has to mean unchanged.
+Each key in it is treated differently, and each is pinned by a named test in
+`tests/core/test_leak_boundary.py` rather than by a property — a property
+broad enough to cover them would have to be weak enough to say nothing:
+
+- `class` is **written by the compiler**: a workflow-level value you supply
+  does not survive.
+- `inputs` and `outputs` are **merged into**, with the compiler winning on a
+  collision: entries you write survive unless the compiler generates one of
+  the same name. `outputs` is additionally *read* — each entry's
+  `outputSource` feeds the compiler's output mapping — so a workflow-level
+  `outputs:` is interpreted, not merely tolerated.
+- `cwlVersion` is **written by the compiler**: it is always the one declared
+  substrate version, whatever the document says. Sophios generates constructs
+  from that version — a workflow that declared `v1.0` and used `when:` used to
+  keep the declaration and emit CWL that is invalid against it. Supplying the
+  tag is not an error; it is ignored, with a warning naming the version that
+  was used instead.
+- `requirements` is **merged into**: your entries survive, and Sophios adds
+  what the workflow needs — `ScatterFeatureRequirement` for a scattering step,
+  `InlineJavascriptRequirement` for `when` or `valueFrom`,
+  `SubworkflowFeatureRequirement` for a `.wic` step. The mapping you wrote is
+  extended, not replaced, and not copied out byte-identically.
+- `$schemas` is **append-only**: your entries survive and the EDAM entry is
+  added once.
+- `$namespaces` is **merged, with one reserved prefix**: every binding you
+  write survives except `edam`, which is replaced by the canonical one.
+
+Everything outside the compiler-owned row survives byte-identically, which is
+the statement the properties in that file quantify over.
 
 ---
 

--- a/src/sophios/compiler.py
+++ b/src/sophios/compiler.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, NamedTuple, cast
@@ -18,6 +19,8 @@ from .wic_types import (CompilerInfo, CompilerOptions, EnvData, ExplicitEdgeCall
                         WorkflowOutputs, Yaml, YamlTagPaths, YamlTree, StepId)
 from .lang.cwl import CWL_VERSION
 from .lang.diagnostics import Code, SophiosError
+
+logger = logging.getLogger('sophios')
 
 # NOTE: This must be initialized in main.py and/or cwl_subinterpreter.py
 inference_rules: dict[str, str] = {}
@@ -202,7 +205,21 @@ def _prepare_compilation_state(yaml_tree_ast: YamlTree,
     # runs cromwell (cwltool and toil are the supported runners), and 1.2 is
     # what conditional workflows already rely on. A static scan bans version
     # literals outside the owner module (tests/core/test_cwl_version.py).
-    yaml_tree['cwlVersion'] = yaml_tree.get('cwlVersion', CWL_VERSION)
+    #
+    # The compiler wins, rather than defaulting to its version only when the
+    # document is silent. Sophios compiles for one substrate version and emits
+    # constructs from it — a document that declared v1.0 kept the declaration
+    # and still got `when:`, which is v1.2-only, so the output was invalid CWL
+    # and cwltool said so. Honouring the tag would mean generating for the
+    # version it names, which is a different compiler.
+    declared_version = yaml_tree.get('cwlVersion')
+    if declared_version is not None and declared_version != CWL_VERSION:
+        logger.warning(
+            'Ignoring cwlVersion: %s in %s.wic — Sophios compiles to %s, and the emitted '
+            'workflow may use features %s does not have. The output declares %s and is '
+            'valid against it, so nothing is lost; remove the tag to silence this.',
+            declared_version, yaml_stem, CWL_VERSION, declared_version, CWL_VERSION)
+    yaml_tree['cwlVersion'] = CWL_VERSION
     yaml_tree['class'] = 'Workflow'
     namespaces_value = yaml_tree.get('$namespaces', {})
     if namespaces_value is None:

--- a/tests/core/compile_harness.py
+++ b/tests/core/compile_harness.py
@@ -1,0 +1,47 @@
+"""One way to compile an in-memory workflow in tests.
+
+`compile_workflow` takes fourteen positional arguments, so every test that
+drives the real compiler had grown its own copy of the call: two in the leak
+boundary suite, one in the provocation registry, and — before this module —
+two more arriving with the language-version suite. Five spellings of one call
+is five places to edit when the signature moves, and four of them would be
+found by the compiler failing rather than by anyone noticing.
+
+The split below is the only distinction the call sites actually needed: some
+want the whole `CompilerInfo` (to reach `rose` for post-compilation), most
+want just the emitted CWL.
+"""
+import graphviz
+import networkx as nx
+from hypothesis import HealthCheck, settings
+
+import sophios.cli
+import sophios.compiler
+from sophios.wic_types import CompilerInfo, GraphData, GraphReps, StepId, Yaml, YamlTree
+
+from .test_setup import tools_cwl
+
+#: Shared Hypothesis budgets. Compiled properties are an order of magnitude
+#: slower than parse-only ones, so they get their own, smaller, count.
+FAST = settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+COMPILED = settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+
+#: A minimal real workflow: one tool step, one inline literal input.
+TOUCH: Yaml = {'steps': [{'id': 'touch', 'in': {'filename': {'wic_inline_input': 'empty.txt'}}}]}
+
+
+def compile_info(yml: Yaml, name: str = 'harness') -> CompilerInfo:
+    """Compile one in-memory workflow and return the whole compiler result."""
+    compiler_options, graph_settings, tag_paths = sophios.cli.default_compilation_settings()
+    graph = GraphReps(graphviz.Digraph(name=f'cluster_{name}'), nx.DiGraph(), GraphData(name))
+    return sophios.compiler.compile_workflow(
+        YamlTree(StepId(name, 'global'), yml),
+        compiler_options, graph_settings, tag_paths,
+        [], [graph], {}, {}, {}, {},
+        tools_cwl, True, relative_run_path=True, testing=True)
+
+
+def compile_cwl(yml: Yaml, name: str = 'harness') -> Yaml:
+    """Compile one in-memory workflow and return the emitted CWL."""
+    compiled: Yaml = compile_info(yml, name).rose.data.compiled_cwl
+    return compiled

--- a/tests/core/provocations.py
+++ b/tests/core/provocations.py
@@ -39,22 +39,15 @@ COMPILED: Final[dict[Code, Callable[[], object]]] = {}
 
 
 def _compile_minimal(yml: dict) -> None:
-    """Compile one in-memory workflow with the real tool registry."""
-    import graphviz  # pylint: disable=import-outside-toplevel
-    import networkx as nx  # pylint: disable=import-outside-toplevel
+    """Compile one in-memory workflow with the real tool registry.
 
-    import sophios.cli  # pylint: disable=import-outside-toplevel
-    import sophios.compiler  # pylint: disable=import-outside-toplevel
-    from sophios.wic_types import GraphData, GraphReps, StepId, YamlTree  # pylint: disable=import-outside-toplevel
+    Imported lazily, like everything else here: this module is imported by the
+    meta-test to enumerate codes, and pulling in the compiler and the tool
+    registry to do that would make a cheap import expensive.
+    """
+    from .compile_harness import compile_info  # pylint: disable=import-outside-toplevel
 
-    from .test_setup import tools_cwl  # pylint: disable=import-outside-toplevel
-
-    options, graph_settings, tag_paths = sophios.cli.default_compilation_settings()
-    graph = GraphReps(graphviz.Digraph(name='cluster_provoke'), nx.DiGraph(), GraphData('provoke'))
-    sophios.compiler.compile_workflow(YamlTree(StepId('provoke', 'global'), yml),
-                                      options, graph_settings, tag_paths,
-                                      [], [graph], {}, {}, {}, {},
-                                      tools_cwl, True, relative_run_path=True, testing=True)
+    compile_info(yml, 'provoke')
 
 
 def _provoke_unresolved_input() -> None:

--- a/tests/core/test_leak_boundary.py
+++ b/tests/core/test_leak_boundary.py
@@ -1,0 +1,329 @@
+"""The leak boundary, checked against the real compiler.
+
+Four claims, each a property below: passthrough keys survive compilation
+byte-identically; no key is both interpreted and passed through; the
+interpreted set is exhaustive, so the compiler is inert to everything else;
+and the stripped residue validates as CWL v1.2 under cwltool.
+
+These run the actual `compile_workflow`, not the syntax layer, because the
+boundary being specified is the compiler's behaviour. The syntax layer's
+partition is checked exhaustively over the declared set as well, since
+that is what the schema and the reference derive from.
+
+The keys the compiler owns are the documented exceptions. Their normative
+statement lives in the reference's §1 footnote — the single home — and each is
+enforced by a named test below rather than by a property: `requirements`,
+`inputs` and `outputs` are merged into, `$schemas` is append-only,
+`$namespaces` reserves the `edam` prefix, and `class` and `cwlVersion` are
+written.
+A property broad enough to cover them would have to be weak enough to say
+nothing, so the properties quantify over the keys that really are untouched
+and the exceptions are pinned one at a time.
+
+See design_docs/core-refactor-design.md §5.4.
+"""
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+import sophios.post_compile
+from sophios.lang import Grammar, parse
+from sophios.lang.cwl import CWL_VERSION
+from sophios.wic_types import Yaml
+
+from .compile_harness import COMPILED, FAST, compile_cwl, compile_info
+
+#: Step keys the language claims for itself, and therefore not passthrough.
+#: `wic:` is claimed at every level: §1 lists the block as Sophios-owned, and
+#: a step-level `wic:` is metadata about the step, not CWL bound for the
+#: output — so a property that generated it and then asserted it was
+#: passthrough would be asserting against the reference.
+CLAIMED_STEP_KEYS = frozenset({'id', 'in', 'out', 'wic'}) | Grammar.INTERPRETED_STEP_KEYS
+
+#: Top-level keys the *compiler* owns, which is a larger set than the syntax
+#: layer's. `_document` claims only `steps` and `wic`; `compile_workflow` also
+#: writes `class` and `cwlVersion`, merges into `inputs`, `outputs` and
+#: `requirements`, and reads `outputSource` out of the `outputs` you supply. These properties drive the compiler, so they must
+#: exclude what the compiler owns — the old filter named the parser's two and
+#: was saved from the rest only by the improbability of `st.text` spelling
+#: `class`, which is safety by luck rather than by statement.
+COMPILER_OWNED_TOP_KEYS = frozenset({
+    'steps', 'wic', 'class', 'cwlVersion', 'inputs', 'outputs', 'requirements',
+    '$namespaces', '$schemas',
+})
+
+
+def _compile(yml: Yaml) -> Yaml:
+    """Compile one in-memory workflow and return the emitted CWL."""
+    return compile_cwl(yml, 'leak')
+
+
+def _step(cwl: Yaml) -> Yaml:
+    """The single step of a compiled one-step workflow.
+
+    Always a list: the compiler normalises mapping-form `steps:` away before
+    emitting (`yaml_tree.update({'steps': steps_list})`), so the emitted
+    document has only one shape whatever the source had.
+
+    Returns the live sub-dict, not a copy — callers compare documents after
+    mutating what they get back.
+    """
+    found: Yaml = cwl['steps'][0]
+    return found
+
+
+# --------------------------------------------------------------------------
+# Strategies
+# --------------------------------------------------------------------------
+
+#: Keys that are definitely not claimed by the language. Filtered rather than
+#: constructed, so the claim set stays the authority.
+#:
+#: The sampled half matters: a lowercase-ascii alphabet cannot produce `$` or
+#: an uppercase letter, so `$namespaces`, `$schemas` and `scatterMethod` were
+#: unreachable by construction and no property here ever touched the keys the
+#: reference's footnote is about. Real CWL keys are drawn explicitly.
+passthrough_keys = st.one_of(
+    st.text('abcdefghijklmnopqrstuvwxyz_', min_size=3, max_size=12),
+    st.sampled_from(['$namespaces', '$schemas', 'hints', 'label', 'doc', 'scatterMethod']),
+).filter(lambda k: k not in CLAIMED_STEP_KEYS)
+
+#: JSON-shaped values, byte-comparable after a round trip.
+passthrough_values = st.recursive(
+    st.one_of(st.integers(min_value=-100, max_value=100), st.booleans(),
+              st.text('abc xyz', max_size=8), st.none()),
+    lambda children: st.one_of(st.lists(children, max_size=3),
+                               st.dictionaries(st.text('abc', min_size=1, max_size=5), children, max_size=3)),
+    max_leaves=8,
+)
+
+
+def _touch_workflow(extra_step_keys: dict[str, Any], extra_top_keys: dict[str, Any]) -> Yaml:
+    """A minimal real workflow carrying the given passthrough freight."""
+    return {
+        **extra_top_keys,
+        'steps': [{'id': 'touch',
+                   'in': {'filename': {'wic_inline_input': 'empty.txt'}},
+                   **extra_step_keys}],
+    }
+
+
+# --------------------------------------------------------------------------
+# Passthrough fidelity: unclaimed keys survive byte-identically
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+@given(st.dictionaries(passthrough_keys, passthrough_values, min_size=1, max_size=4))
+@COMPILED
+def test_step_passthrough_is_byte_identical(freight: dict[str, Any]) -> None:
+    """A step key outside the claimed set survives compilation unchanged."""
+    compiled = _compile(_touch_workflow(freight, {}))
+    step = _step(compiled)
+    for key, value in freight.items():
+        assert step[key] == value, f'{key} was altered by compilation'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+@given(st.dictionaries(passthrough_keys.filter(lambda k: k not in COMPILER_OWNED_TOP_KEYS),
+                       passthrough_values, min_size=1, max_size=3))
+@COMPILED
+def test_top_level_passthrough_is_byte_identical(freight: dict[str, Any]) -> None:
+    """An uninterpreted top-level key survives compilation unchanged."""
+    compiled = _compile(_touch_workflow({}, freight))
+    for key, value in freight.items():
+        assert compiled[key] == value, f'{key} was altered by compilation'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_user_namespaces_survive_except_edam() -> None:
+    """The one qualification: `$namespaces` keeps every user binding but `edam`.
+
+    CE-05. The compiler merges `{'edam': the canonical URL}` over the user's
+    mapping, so a user binding of the `edam` prefix specifically is replaced.
+    Pinned as the actual behaviour; if merging ever becomes pure passthrough,
+    this test should fail and be inverted deliberately, not silently.
+    """
+    compiled = _compile(_touch_workflow({}, {'$namespaces': {'mine': 'https://mine/', 'edam': 'https://not-edam/'}}))
+    assert compiled['$namespaces']['mine'] == 'https://mine/'
+    assert compiled['$namespaces']['edam'] == 'https://edamontology.org/'  # user's binding lost
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_class_is_written_while_inputs_outputs_and_version_are_not() -> None:
+    """The other four compiler-owned keys, each behaving differently.
+
+    These four had no test behind them, and the footnote claiming each was
+    pinned was wrong about three: `inputs`/`outputs` are merged, not written
+    (`{**yours, **generated}`, so your entry survives unless the compiler
+    generates the same name), and `cwlVersion` used to be *defaulted* — a
+    document declaring `v1.0` kept it and still received `when:`, emitting CWL
+    that cwltool rejects against the version it names. The compiler now writes
+    it. A row asserting facts about the compiler needs a test per fact, or it
+    is prose that drifts.
+    """
+    # `outputs` entries are *read*, not merely kept: the compiler pulls
+    # `outputSource` out of each one, so a supplied entry needs a real one.
+    user_output = {'type': 'File', 'outputSource': 'touch/file'}
+    compiled = _compile({
+        'class': 'ExpressionTool',        # a lie the compiler must overwrite
+        'inputs': {'mine': {'type': 'string'}},
+        'outputs': {'mine': user_output},
+        'cwlVersion': 'v1.0',             # older than the declared substrate
+        **_touch_workflow({}, {}),
+    })
+
+    assert compiled['class'] == 'Workflow', 'class is written, not merged'
+    assert compiled['inputs']['mine'] == {'type': 'string'}, 'user input lost'
+    assert len(compiled['inputs']) > 1, 'compiler inputs not merged alongside'
+    assert compiled['outputs']['mine'] == user_output, 'user output lost'
+    assert len(compiled['outputs']) > 1, 'compiler outputs not merged alongside'
+
+    # The compiler wins. Sophios generates for one substrate version, so a
+    # document cannot claim another and still be valid: declaring v1.0 and
+    # receiving `when:` produced CWL that cwltool rejects. The tag is ignored
+    # with a warning rather than refused — a stale pin should not stop a
+    # workflow compiling.
+    assert compiled['cwlVersion'] == CWL_VERSION, 'a supplied cwlVersion must not win'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_user_requirements_are_merged_into_not_copied() -> None:
+    """`requirements` keeps what you wrote and gains what the workflow needs.
+
+    The third compiler-owned key, and the one the reference used to list as an
+    example of pure passthrough. `maybe_add_requirements` fires whenever a step
+    scatters, uses `when` or `valueFrom`, or names a `.wic` subworkflow — so a
+    workflow that supplies its own `requirements` gets them back extended, not
+    unchanged. The generated properties never see it: their one step is a plain
+    tool step, so the requirement set is empty and the merge is skipped on
+    every example.
+    """
+    compiled = _compile({
+        'requirements': {'ResourceRequirement': {'coresMin': 4}},
+        'steps': [{'id': 'touch',
+                   'in': {'filename': {'wic_inline_input': 'empty.txt'}},
+                   'scatter': ['filename']}],
+    })
+    requirements = compiled['requirements']
+    assert requirements['ResourceRequirement'] == {'coresMin': 4}, 'user entry lost'
+    assert 'ScatterFeatureRequirement' in requirements, 'scatter requirement not added'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_user_schemas_are_kept_and_appended_to() -> None:
+    """`$schemas` is append-only: user entries survive, Sophios adds its own."""
+    compiled = _compile(_touch_workflow({}, {'$schemas': ['https://mine/schema.owl']}))
+    assert 'https://mine/schema.owl' in compiled['$schemas']
+
+
+# --------------------------------------------------------------------------
+# The interpreted/passthrough partition really is a partition
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('key', sorted(Grammar.INTERPRETED_STEP_KEYS))
+def test_every_declared_key_is_interpreted(key: str) -> None:
+    """Exhaustive half: each declared key routes to `interpreted`."""
+    result = parse(f'steps:\n- id: s\n  {key}: x\n', 'p11.wic')
+    assert result.document is not None
+    step = result.document.steps[0]
+    assert key in dict(step.interpreted)
+    assert key not in dict(step.passthrough)
+
+
+@pytest.mark.fast
+@given(passthrough_keys)
+@FAST
+def test_no_key_lands_on_both_sides(key: str) -> None:
+    """Generated half: any other key routes to passthrough, never both."""
+    result = parse(f'steps:\n- id: s\n  {key}: x\n', 'p11.wic')
+    assert result.document is not None
+    step = result.document.steps[0]
+    interpreted, passthrough = dict(step.interpreted), dict(step.passthrough)
+    assert key in passthrough
+    assert key not in interpreted
+    assert not set(interpreted) & set(passthrough)
+
+
+# --------------------------------------------------------------------------
+# The compiler is inert outside the declared set
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+@given(passthrough_keys, passthrough_values)
+@COMPILED
+def test_unknown_keys_change_nothing_else(key: str, value: Any) -> None:
+    """Adding an uninterpreted key changes exactly that key and nothing
+    else in the output — the observable meaning of "not interpreted".
+    """
+    without = _compile(_touch_workflow({}, {}))
+    with_key = _compile(_touch_workflow({key: value}, {}))
+
+    # The whole document, not just the step: `maybe_add_requirements` reads
+    # step keys and writes a *top-level* key, so a step key reaching that path
+    # would change the document while leaving the step subtree identical — and
+    # comparing only the step would call that inert. `_step` returns a
+    # reference into `with_key`, so popping there removes the key from the
+    # document being compared.
+    assert _step(with_key).pop(key) == value
+    assert with_key == without, f'{key} altered more than itself'
+
+
+# --------------------------------------------------------------------------
+# The residue is real CWL v1.2
+# --------------------------------------------------------------------------
+
+#: Passthrough spelled in CWL vocabulary, because CWL v1.2 itself rejects
+#: unknown step fields — arbitrary keys are covered by the fidelity properties
+#: above, but a document carrying them is not *valid CWL*, and this last claim
+#: is about validity.
+cwl_passthrough = st.fixed_dictionaries(
+    {},
+    optional={
+        'label': st.text('abc xyz', min_size=1, max_size=20),
+        'doc': st.text('abc xyz.', min_size=1, max_size=40),
+        'hints': st.just({'LoadListingRequirement': {'loadListing': 'shallow_listing'}}),
+    },
+)
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+# Ten examples, not the shared hundred: `cwl_passthrough` varies only in which
+# of three optional keys are present — eight shapes — and the free text inside
+# `label`/`doc` cannot change whether a document is valid CWL. Hypothesis keeps
+# drawing new strings and so never detects the exhaustion, spending about a
+# minute and a half of CI on a claim eight examples settle.
+@given(cwl_passthrough)
+@settings(max_examples=10, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+def test_residue_validates_as_cwl_v1_2(freight: dict[str, Any]) -> None:
+    """Strip the Sophios syntax, inline the tools, and cwltool agrees the
+    residue is CWL v1.2."""
+    import cwltool.main  # pylint: disable=import-outside-toplevel  # expensive; slow lane only
+
+    info = compile_info(_touch_workflow(freight, {}), 'leak')
+    inlined = sophios.post_compile.cwl_inline_runtag(info.rose).data.compiled_cwl
+
+    # A throwaway file, not a repo artifact: it exists only to hand cwltool a
+    # path. `tmp_path` would be the obvious choice, but it is function-scoped
+    # and Hypothesis rightly refuses to reuse one fixture across examples.
+    with tempfile.TemporaryDirectory() as workdir:
+        target = Path(workdir) / 'residue.cwl'
+        target.write_text(yaml.safe_dump(inlined, sort_keys=False), encoding='utf-8')
+        assert cwltool.main.main(['--validate', '--quiet', str(target)]) == 0
+    assert inlined['cwlVersion'] == CWL_VERSION


### PR DESCRIPTION
Stacks on #386 (`semrefac_5`); the single commit after its tip is this PR — tests only, no behaviour change.

The interpreted set was declared in one place but never checked against the compiler that is supposed to honour it, so these properties run `compile_workflow` itself rather than the syntax layer. Passthrough fidelity: any step-level or top-level key outside the claimed set survives compilation byte-identically. Partition soundness: the parser routes each declared key to `interpreted` and everything else to `passthrough`, exhaustively over the declared set and never to both. Exhaustiveness gets the strongest formulation available: the compiler is provably inert outside the declared set — adding an unknown key to a workflow changes exactly that key in the output and nothing else, which is the observable meaning of "not interpreted". And the residue is real CWL: compiled output with tools inlined is validated by `cwltool` itself, not by anything Sophios maintains. The `--allow_raw_cwl` boundary is also pinned: the same bare unresolved name is a report without the flag and compiles with it.

The properties found one exception, documented rather than papered over (CE-05): `$namespaces` is not pure passthrough. The compiler merges its own `edam` binding over the user's mapping, so a workflow that binds the `edam` prefix itself loses that binding in the output; every other namespace survives, and `$schemas` is append-only. The `edam` prefix is effectively reserved. Correcting the reference instead of the behaviour is deliberate — changing the merge would alter emitted CWL for every existing workflow that relies on the injected namespace, which is a compatibility decision for a maintainer, not a test. The property asserts the true behaviour, so a future change to the merge is a visible failure in either direction.
