### PR TITLE
ci: retire every action still on node20 and below

### DIFF
--- a/.github/workflows/branch_dispatch_pull_request.yml
+++ b/.github/workflows/branch_dispatch_pull_request.yml
@@ -17,10 +17,14 @@ jobs:
       - name: Generate a token
         if: always()
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # tibdex minted a token for the whole app installation; the official
+          # action defaults to the current repository only. owner: restores
+          # installation scope, which cross-repo branch dispatch requires.
+          owner: ${{ github.repository_owner }}
 
       # !!!!!! CRITICAL: PLEASE READ !!!!!!
       # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions- settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories

--- a/.github/workflows/branch_dispatch_push.yml
+++ b/.github/workflows/branch_dispatch_push.yml
@@ -17,10 +17,14 @@ jobs:
       - name: Generate a token
         if: always()
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # tibdex minted a token for the whole app installation; the official
+          # action defaults to the current repository only. owner: restores
+          # installation scope, which cross-repo branch dispatch requires.
+          owner: ${{ github.repository_owner }}
 
       # To use this repository's private action,
       # you must check out the repository

--- a/.github/workflows/branch_dispatch_repository_dispatch.yml
+++ b/.github/workflows/branch_dispatch_repository_dispatch.yml
@@ -19,10 +19,14 @@ jobs:
       - name: Generate a token
         if: always()
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # tibdex minted a token for the whole app installation; the official
+          # action defaults to the current repository only. owner: restores
+          # installation scope, which cross-repo branch dispatch requires.
+          owner: ${{ github.repository_owner }}
 
       # !!!!!! CRITICAL: PLEASE READ !!!!!!
       # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions- settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories

--- a/.github/workflows/fuzzy_compile_weekly.yml
+++ b/.github/workflows/fuzzy_compile_weekly.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Setup miniforge (linux, macos)
         if: runner.os != 'Windows'
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-variant: Miniforge3
           miniforge-version: 24.7.1-2

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -127,7 +127,7 @@ jobs:
       # Completely moving away from pypy
       - name: Setup miniforge (linux, macos)
         if: runner.os != 'Windows'
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-variant: Miniforge3
           miniforge-version: 24.7.1-2
@@ -138,7 +138,7 @@ jobs:
 
       - name: Setup miniforge (windows)
         if: runner.os == 'Windows'
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-variant: Miniforge3
           miniforge-version: 24.7.1-2
@@ -275,10 +275,14 @@ jobs:
       - name: Generate a token
         if: always()
         id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # tibdex minted a token for the whole app installation; the official
+          # action defaults to the current repository only. owner: restores
+          # installation scope, which cross-repo branch dispatch requires.
+          owner: ${{ github.repository_owner }}
 
       - name: Reply CI results to sender
         # In case of failure, we still need to return the failure status to the original repository.

--- a/.github/workflows/lint_and_test_macos.yml
+++ b/.github/workflows/lint_and_test_macos.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup miniforge (linux, macos)
         if: runner.os != 'Windows'
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-variant: Miniforge3
           miniforge-version: 24.7.1-2

--- a/.github/workflows/publish_rest_docker.yml
+++ b/.github/workflows/publish_rest_docker.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx 🐳
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Get Tag
         run: echo "tag=${{ github.ref_name }}" >> $GITHUB_ENV

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json

--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -114,7 +114,7 @@ jobs:
 
     - name: Setup miniforge (linux, macos)
       if: always()
-      uses: conda-incubator/setup-miniconda@v3.0.1
+      uses: conda-incubator/setup-miniconda@v4.0.1
       with:
         miniforge-variant: Miniforge3
         miniforge-version: 24.7.1-2
@@ -232,10 +232,14 @@ jobs:
     - name: Generate a token
       if: always()
       id: generate_token
-      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+      uses: actions/create-github-app-token@v3
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.APP_PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        # tibdex minted a token for the whole app installation; the official
+        # action defaults to the current repository only. owner: restores
+        # installation scope, which cross-repo branch dispatch requires.
+        owner: ${{ github.repository_owner }}
 
     - name: Reply CI results to sender
       # In case of failure, we still need to return the failure status to the original repository.

--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Setup miniforge (linux, macos)
       if: always()
-      uses: conda-incubator/setup-miniconda@v3.0.1
+      uses: conda-incubator/setup-miniconda@v4.0.1
       with:
         miniforge-variant: Miniforge3
         miniforge-version: 24.7.1-2

--- a/.github/workflows/token.md
+++ b/.github/workflows/token.md
@@ -80,7 +80,7 @@ actions. When using third-party actions, it is the best to specify the SHA code
 or the tag of the commit you want to use, [preventing bad actors to alter behaviors
 of the actions and create security loopholes](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
 
-Currently, we use the third-party action `tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92`, as demonstrated in [this
+Currently, we use the official action `actions/create-github-app-token@v3` (which replaced the archived `tibdex/github-app-token`), as demonstrated in [this
 example](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow)
 in GitHub docs.
 


### PR DESCRIPTION
Kills the "Node 20 is being deprecated" warnings in `lint_and_test` (and everywhere else they were about to appear) at their actual source. The earlier CI modernisation covered everything this repository owns — the four vendored actions declare `node24` and checkout is on v5 — but four third-party pins still requested deprecated runtimes, and a warning names the workflow, not the offending action, which is why it looked already-fixed.

The worst was `tibdex/github-app-token`, pinned to a SHA that runs **node16** with the upstream repository archived — replaced at all five sites with the official `actions/create-github-app-token@v3` (node24). One behavioural detail matters: tibdex minted a token for the whole app installation, while the official action defaults to the current repository only, so `owner:` is set explicitly to keep the installation scope that cross-repo branch dispatch to mm-workflows and image-workflows requires. `conda-incubator/setup-miniconda` moves from v3.0.1 (node20) — and a stray v2.2.0 on the macOS lane — to v4.0.1 (node24) at all six sites; v4's breaking change is the runtime itself. `docker/setup-buildx-action@v1` was still on **node12**, three majors behind its siblings in the same workflow; now v4. And release-please, pinned to a SHA in the deprecated `google-github-actions` org, moves to `googleapis/release-please-action@v5` — the v3→v4 breaking change was manifest-driven config, which this repository already uses, so v5 is a drop-in and the `release_created`/`tag_name`/`version` outputs are unchanged for a single-component manifest.

After this, no action in the tree requests a runtime below node24. `token.md` now names the official token action so the docs stop recommending the archived one.
