### PR TITLE
Spec 1: one owner for the unknown-tag rule, so key position stops being exempt

### DIFF
--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -329,12 +329,7 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     if build is not None:
         return build(node, file, diags, span)
 
-    if node.tag.startswith('!'):
-        # A tag the language does not own. The loader rejects this outright,
-        # and the specification must never be more permissive than the thing
-        # it specifies; the payload is kept, untagged, for recovery.
-        diags.error(Code.UNKNOWN_TAG,
-                    f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl', span)
+    _reject_unknown_tag(node, file, diags, span)
 
     desugared = _desugared_form(node, file, diags, span)
     if desugared is not None:
@@ -596,13 +591,7 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
         return None
     path = _path | {id(node)}
 
-    if node.tag.startswith('!') and node.tag not in Tag.ALL:
-        # Passthrough is CWL, and CWL has no custom YAML tags: the loader
-        # rejects this text, so accepting it here would specify a superset of
-        # the language. Reported; the payload is materialised for recovery.
-        diags.error(Code.UNKNOWN_TAG,
-                    f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl',
-                    SourceSpan.of(file, node))
+    _reject_unknown_tag(node, file, diags)
 
     if node.tag in (Tag.ANCHOR, Tag.ALIAS, Tag.RAW_CWL) or (
             node.tag == Tag.INLINE_INPUT and isinstance(node, yaml.nodes.ScalarNode)):
@@ -678,12 +667,38 @@ def _key_text(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> str:
     YAML admits collection keys (`? [a, b]`); Sophios does not — every key in
     the language is a name. A non-scalar key is reported and stringified for
     recovery, rather than silently becoming the repr of a node list.
+
+    A key can also carry a tag, and this is the position that used to forget
+    it: `!: :` composed to a mapping whose key node was tagged, the tag was
+    dropped by the stringify below, and the parser accepted a document the
+    loader refuses — the one direction the language promises never to take.
     """
+    _reject_unknown_tag(node, file, diags)
     if not isinstance(node, yaml.nodes.ScalarNode):
         diags.error(Code.EXPECTED_SCALAR,
                     f'mapping keys must be scalars, found {_kind(node)}',
                     SourceSpan.of(file, node))
     return str(node.value)
+
+
+def _reject_unknown_tag(node: yaml.nodes.Node, file: str, diags: Diagnostics,
+                        span: SourceSpan | None = None) -> None:
+    """Report a tag the language does not own, wherever it appears.
+
+    One home for the rule, deliberately. It used to be written out at each
+    position that consumes a node — once for input values, once for the
+    passthrough walk — and a third position, mapping keys, simply never got a
+    copy. Restating a rule per position is how a position gets missed; now a
+    new one has a single obvious thing to call.
+
+    The rule itself: Sophios owns four tags, the loader rejects every other,
+    and the specification must never be more permissive than the thing it
+    specifies. The payload is kept, untagged, for recovery.
+    """
+    if node.tag.startswith('!') and node.tag not in Tag.ALL:
+        diags.error(Code.UNKNOWN_TAG,
+                    f'unknown tag {node.tag!r}; the Sophios tags are !ii, !&, !*, and !cwl',
+                    span if span is not None else SourceSpan.of(file, node))
 
 
 def _kind(node: yaml.nodes.Node) -> str:

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -515,11 +515,19 @@ def test_unknown_tags_report_wic009(source: str) -> None:
 @pytest.mark.fast
 @given(st.text('abcdefghijklmnopqrstuvwxyz!&*i {}[]:#-', max_size=120))
 @FAST
+@example('!: :')      # unknown tag on a mapping *key* — the position that was missed
+@example('!foo x: y')  # the same, spelled legibly
 def test_parser_is_not_more_permissive_than_the_loader(text: str) -> None:
     """Any document the parser accepts without diagnostics, the loader loads.
 
     The reverse is allowed — the parser recovers where the loader raises — but
     this direction is the specification's half of the bargain.
+
+    The pinned cases are tags in key position. The property found `!: :` on
+    its own, months after the tag rule was written, because the alphabet only
+    rarely composes a tagged key — which is exactly why it is pinned now:
+    Hypothesis's failure database does not travel to CI, so a find that came
+    from one lucky seed would otherwise be re-discovered by luck or not at all.
     """
     result = parse(text, 'agree.wic')
     if result.ok and result.document is not None:


### PR DESCRIPTION
`!: :` — a mapping whose key carries an unknown tag — parsed clean, with no diagnostic, while `yaml.load` refuses the same text outright. That is the one direction the language promises never to take, and `test_parser_is_not_more_permissive_than_the_loader` exists precisely to forbid it. The property found it on its own, months after the tag rule was written, on a seed that happened to compose a tagged key.

**The cause was duplication, not oversight.** The rule "Sophios owns four tags, everything else is `wic009`" was spelled out separately at each position that consumes a node — once in `_input_value`, once in the passthrough walk `_opaque` — and mapping keys, a third position, never received a copy. `_key_text` checked the node's *kind* (scalar versus collection, reporting `wic005`) and then did `str(node.value)`, which silently discards any tag. That path has ten callers, so every step id, mapping-form step name, `wic:` entry, `wic:` step key, and passthrough key has been quietly accepting tagged keys and dropping the tag.

So the fix is not a third copy of the check. `_reject_unknown_tag` now owns the rule and all three positions call it — a fourth position gets one obvious thing to call instead of a comment to imitate.

Both spellings are pinned as `@example` on the property. The alphabet only rarely composes a tagged key, and Hypothesis's failure database does not travel to CI, so an unpinned find is re-discovered by luck or not at all. Reverting the fix fails the property; I checked.

**Scope:** parser and one test. No behavioural change for any document that was already valid — the corpus and the full suite are unaffected (407 passed, 2 skipped). What changes is that four spellings which used to parse silently now report `wic009`, matching what the loader has always done with them.

**Stacking:** branches off master directly. #387 and #388 are rebased on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
