### PR TITLE
ci: pin nodejs below 26.8 so cwltool can parse its version

### DIFF
--- a/install/system_deps.yml
+++ b/install/system_deps.yml
@@ -4,8 +4,14 @@ channels:
 
 dependencies:
   - "python>=3.11"
-# NOTE: cwltool needs nodejs for InlineJavascriptRequirement
-  - nodejs
+# NOTE: cwltool needs nodejs for InlineJavascriptRequirement.
+# Pinned below 26.8: conda-forge published 26.8.0 with a pre-release version
+# string, and cwltool's sandboxjs splits `node --version` on '.' and calls
+# int() on each part, so `0-alpha` raises ValueError and every workflow fails
+# to load with "I'm sorry, I couldn't load this CWL file". Nothing in this
+# repository changed — 26.6.0 passed and 26.8.0 failed hours later on the same
+# commits. Lift the ceiling once cwltool parses pre-release node versions.
+  - nodejs<26.8
   - graphviz
 # "Warning: Could not load "/miniconda/bin/../lib/graphviz/libgvplugin_pango.so.6"
 #  - It was found, so perhaps one of its dependents was not.  Try ldd."

--- a/install/system_deps_windows.yml
+++ b/install/system_deps_windows.yml
@@ -4,8 +4,14 @@ channels:
 
 dependencies:
   - "python>=3.11"
-# NOTE: cwltool needs nodejs for InlineJavascriptRequirement
-  - nodejs
+# NOTE: cwltool needs nodejs for InlineJavascriptRequirement.
+# Pinned below 26.8: conda-forge published 26.8.0 with a pre-release version
+# string, and cwltool's sandboxjs splits `node --version` on '.' and calls
+# int() on each part, so `0-alpha` raises ValueError and every workflow fails
+# to load with "I'm sorry, I couldn't load this CWL file". Nothing in this
+# repository changed — 26.6.0 passed and 26.8.0 failed hours later on the same
+# commits. Lift the ceiling once cwltool parses pre-release node versions.
+  - nodejs<26.8
   - graphviz
 # "Warning: Could not load "/miniconda/bin/../lib/graphviz/libgvplugin_pango.so.6"
 #  - It was found, so perhaps one of its dependents was not.  Try ldd."


### PR DESCRIPTION
conda-forge published `nodejs 26.8.0` with a pre-release version string. cwltool's `sandboxjs` splits `node --version` on `.` and calls `int()` on each part, so it raises `invalid literal for int() with base 10: '0-alpha'` and refuses to load any workflow. `install/system_deps.yml` asked for unpinned `nodejs`, so CI took it the moment it appeared and went red everywhere.

Pinning `nodejs<26.8` costs us nothing. Node is here solely because cwltool shells out to it for `InlineJavascriptRequirement`; we use no Node features and have no reason to track its releases. When cwltool learns to parse pre-release versions we can lift the ceiling — I don't expect to want that for a year or more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
