### PR TITLE
style: bring every line within the configured width, and enforce it

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,8 @@ CONTRIB_DIR = Path(__file__).resolve().parent / 'tests' / 'contrib'
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption('--cwl_runner', type=str, required=False, default='cwltool', choices=['cwltool', 'toil-cwl-runner'],
+    parser.addoption('--cwl_runner', type=str, required=False, default='cwltool',
+                     choices=['cwltool', 'toil-cwl-runner'],
                      help='The CWL runner to use for running workflows locally.')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,9 +254,6 @@ fail-under=9.25
 
 [tool.pylint.format]
 
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines='^\s*(# )?(See )?(and )?<?https?://\S+>?$'
-
 # Maximum number of characters on a single line.
 max-line-length=120
 

--- a/src/sophios/cli.py
+++ b/src/sophios/cli.py
@@ -133,7 +133,8 @@ parser.add_argument('--custom_net', type=str, required=False,
                     help='Passes --custom-net flag to cwltool.')
 parser.add_argument('--passthrough_flags', type=str, default='no', required=False,
                     help='''Indicates that the user is passing flags to the cwl_runner backend.
-                    No checks are done on the flags or values passed. User must verify that they are sending correct flags.
+                    No checks are done on the flags or values passed.
+                    User must verify that they are sending correct flags.
                     only two valid values of this flag 'yes' or 'no'.
                     If set to 'no' (default) passthrough flags won't be sent to the cwl_runner backend.''')
 

--- a/src/sophios/inference.py
+++ b/src/sophios/inference.py
@@ -182,7 +182,8 @@ def perform_edge_inference(inference_use_naming_conventions: bool,
         in_name_in_inputs_file_workflow (bool): Used to determine whether\n
         failure to find a match should be considered an error.
         arg_key_in_yaml_tree_inputs (bool): Determines whether at least one level of recursion has been performed.
-        insertions (list[StepId]): If exact inference fails, a list of possible steps to automatically insert is stored here.
+        insertions (list[StepId]): If exact inference fails, a list of possible
+            steps to automatically insert is stored here.
         wic_steps (Yaml): The metadata associated with the given workflow.
         testing: Used to disable some optional features which are unnecessary for testing.
 

--- a/src/sophios/run_local.py
+++ b/src/sophios/run_local.py
@@ -148,7 +148,6 @@ def build_cmd(workflow_name: str, basepath: str, cwl_runner: str,
     now = datetime.now()
     date_time = now.strftime("%Y_%m_%d_%H.%M.%S")
     runner_outdir = _runner_outdir(basepath, cwl_runner, date_time, outdir)
-    # See https://github.com/common-workflow-language/cwltool/blob/5a645dfd4b00e0a704b928cc0bae135b0591cc1a/cwltool/command_line_tool.py#L94
     # NOTE: Using --leave-outputs to disable --outdir
     # See https://github.com/dnanexus/dx-cwl/issues/20
     # --outdir has one or more bugs which will cause workflows to fail!!!

--- a/src/sophios/schemas/wic_schema.py
+++ b/src/sophios/schemas/wic_schema.py
@@ -316,7 +316,6 @@ def _wic_tag_schema(hypothesis: bool = False) -> Json:
     """The (recursive) schema of the wic: metadata annotation tag."""
     # NOTE: This schema needs to be recursive. Use dynamic anchors / references.
     # See https://json-schema.org/draft/2020-12/json-schema-core.html#dynamic-ref
-    # and https://stackoverflow.com/questions/69728686/explanation-of-dynamicref-dynamicanchor-in-json-schema-as-opposed-to-ref-and
 
     # TODO: restrict the str to the enum of all valid step keys
     pat_int_str = "\\([0-9]+, [A-Za-z0-9_\\.]+\\)"

--- a/src/sophios/wic_types.py
+++ b/src/sophios/wic_types.py
@@ -16,7 +16,6 @@ RawJson: TypeAlias = str
 Yaml: TypeAlias = dict[str, Any]
 
 # In python there are unfortunately an enormous number of ways to represent the humble struct.
-# See https://stackoverflow.com/questions/53409117/what-are-the-main-differences-of-namedtuple-and-typeddict-in-python-mypy
 # I have chosen to use NamedTuple to emphasize the immutability aspect (see below).
 # See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#named-tuples
 

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -392,7 +392,8 @@ def test_inline_subworkflows(yml_path_str: str, yml_path: Path) -> None:
     compiler_options, graph_settings, yaml_tag_paths = sophios.cli.get_dicts_for_compilation(args)
 
     graph = get_graph_reps(str(yml_path))
-    compiler_info = sophios.compiler.compile_workflow(yaml_tree, compiler_options, graph_settings, yaml_tag_paths, [], [graph], {},
+    compiler_info = sophios.compiler.compile_workflow(yaml_tree, compiler_options, graph_settings,
+                                                      yaml_tag_paths, [], [graph], {},
                                                       {}, {}, {}, tools_cwl, True, relative_run_path=True, testing=True)
     rose_tree = compiler_info.rose
     sub_node_data: NodeData = rose_tree.data
@@ -404,7 +405,8 @@ def test_inline_subworkflows(yml_path_str: str, yml_path: Path) -> None:
         inline_yaml_tree, _len_substeps = sophios.inlineing.inline_subworkflow(yaml_tree, namespaces)
 
         inline_graph = get_graph_reps(str(yml_path))
-        inline_compiler_info = sophios.compiler.compile_workflow(inline_yaml_tree, compiler_options, graph_settings, yaml_tag_paths,
+        inline_compiler_info = sophios.compiler.compile_workflow(inline_yaml_tree, compiler_options,
+                                                                 graph_settings, yaml_tag_paths,
                                                                  [], [inline_graph], {}, {}, {}, {}, tools_cwl, True,
                                                                  relative_run_path=True, testing=True)
         inline_rose_tree = inline_compiler_info.rose

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -95,13 +95,14 @@ desugared_payload_texts = st.one_of(opaque_payload_texts, construct_payload_text
 
 
 @st.composite
-def input_lines(draw: st.DrawFn, name: str | None = None, indent: str = '      ') -> str:  # pylint: disable=too-many-return-statements
+def input_lines(draw: st.DrawFn, name: str | None = None, indent: str = '      ') -> str:
     """One `in:` binding, in any of the forms the language admits.
 
     Both spellings of each construct are generated — the tagged form people
     write and the desugared form tooling emits — so the properties quantify
     over the language, not over the half of it the tests happened to spell.
     """
+    # pylint: disable=too-many-return-statements  # one return per surface form
     name = draw(identifiers) if name is None else name
     form = draw(st.sampled_from(['ii', 'anchor', 'alias', 'cwl', 'bare',
                                  'ii_desugared', 'anchor_desugared', 'alias_desugared', 'cwl_desugared']))

--- a/tests/core/test_leak_boundary.py
+++ b/tests/core/test_leak_boundary.py
@@ -48,10 +48,11 @@ CLAIMED_STEP_KEYS = frozenset({'id', 'in', 'out', 'wic'}) | Grammar.INTERPRETED_
 #: Top-level keys the *compiler* owns, which is a larger set than the syntax
 #: layer's. `_document` claims only `steps` and `wic`; `compile_workflow` also
 #: writes `class` and `cwlVersion`, merges into `inputs`, `outputs` and
-#: `requirements`, and reads `outputSource` out of the `outputs` you supply. These properties drive the compiler, so they must
-#: exclude what the compiler owns — the old filter named the parser's two and
-#: was saved from the rest only by the improbability of `st.text` spelling
-#: `class`, which is safety by luck rather than by statement.
+#: `requirements`, and reads `outputSource` out of the `outputs` you supply.
+#: These properties drive the compiler, so they must exclude what the compiler
+#: owns — the old filter named the parser's two and was saved from the rest
+#: only by the improbability of `st.text` spelling `class`, which is safety by
+#: luck rather than by statement.
 COMPILER_OWNED_TOP_KEYS = frozenset({
     'steps', 'wic', 'class', 'cwlVersion', 'inputs', 'outputs', 'requirements',
     '$namespaces', '$schemas',

--- a/tests/core/test_zone_boundary.py
+++ b/tests/core/test_zone_boundary.py
@@ -23,11 +23,15 @@ result therefore means "no statically visible crossing", which is weaker than
 instrumentation; that is not what this test does.
 """
 import ast
+import subprocess
 from pathlib import Path
+from typing import Final
 
 import pytest
 
-SRC_ROOT = Path(__file__).resolve().parents[2] / 'src'
+REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+
+SRC_ROOT = REPO_ROOT / 'src'
 PACKAGE = 'sophios'
 
 # The peripheral zone is a single subtree. Everything else under src/sophios
@@ -181,3 +185,59 @@ def test_contrib_may_import_core() -> None:
     assert any(
         any(not _is_contrib(t) for t in _reachable(m, graph)) for m in contrib
     ), 'expected contrib to depend on core; the scan may be resolving nothing'
+
+
+def _repo_python_files() -> list[Path]:
+    """Every tracked Python file. Via git, so build output is excluded.
+
+    Returns nothing outside a git checkout — an sdist ships `tests/` but no
+    `.git` — and the guard below turns that into a skip rather than a silent
+    pass. `-z` because git quotes unusual filenames otherwise, and an explicit
+    encoding because git emits UTF-8 while `text=True` decodes with the
+    locale's, which is cp1252 on Windows.
+    """
+    listing = subprocess.run(['git', 'ls-files', '-z', '*.py'], cwd=REPO_ROOT,
+                             capture_output=True, text=True, encoding='utf-8',
+                             check=False)
+    if listing.returncode != 0:
+        return []
+    return [REPO_ROOT / name for name in listing.stdout.split('\0') if name]
+
+# --------------------------------------------------------------------------
+# Lines stay within the configured width
+# --------------------------------------------------------------------------
+
+
+#: Matches pyproject's max-line-length.
+MAX_LINE_LENGTH: Final = 120
+
+
+def _over_long_lines(path: Path) -> list[tuple[int, int]]:
+    """Line numbers and lengths that exceed the limit. No exemptions."""
+    return [(number, len(line))
+            for number, line in enumerate(path.read_text(encoding='utf-8').splitlines(), start=1)
+            if len(line) > MAX_LINE_LENGTH]
+
+
+@pytest.mark.fast
+def test_the_width_scan_sees_the_repo() -> None:
+    """Zero parametrized cases is a green test that enforces nothing."""
+    if not (REPO_ROOT / '.git').exists():
+        pytest.skip('not a git checkout; nothing to enumerate')
+    assert _repo_python_files(), 'git ls-files resolved nothing; the width scan is vacuous'
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('path', _repo_python_files(),
+                         ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_no_line_exceeds_the_configured_width(path: Path) -> None:
+    """No Python file carries a line longer than pyproject allows.
+
+    autopep8 does not reflow comments and pylint gates on a score, so nothing
+    else enforces the setting.
+    """
+    offenders = _over_long_lines(path)
+    assert not offenders, (
+        f'{path.relative_to(REPO_ROOT)} has lines over {MAX_LINE_LENGTH} columns: '
+        f'{[f"line {n} ({length})" for n, length in offenders]}'
+    )


### PR DESCRIPTION
`test_leak_boundary.py:51` was 126 characters: my wording fix in #387 replaced a sentence without re-wrapping, so it ran into the following clause.

Eight more violations predated it. Six wrap. The other three were bare links, and deleting them costs no understanding:

- `run_local.py` — a permalink into cwltool at a pinned SHA with no statement of what is there. The three lines under it name the actual constraint (`--leave-outputs` to disable `--outdir`, which has bugs) and carry their own issue link.
- `wic_schema.py` — a StackOverflow explainer of `$dynamicRef`/`$dynamicAnchor`, directly beneath the json-schema.org spec link for the same feature and a NOTE stating why the schema must be recursive.
- `wic_types.py` — a StackOverflow survey of struct-like types, beside the sentence that states the decision ("NamedTuple, to emphasize immutability") and the mypy docs link that supports it.

In each case the reason lives in the surrounding lines; the link was a second, weaker source for something already said.

The width is now a test in `test_zone_boundary.py`, with **no exemption** — not even for URLs, since all three that would have needed one were worth deleting. If a permalink ever genuinely needs the room, that is a decision to make in the test rather than a hole left open in advance.

Worth knowing why nothing caught this: autopep8 does not reflow comments, and pylint gates on a score that one long line never moves.
