### PR TITLE
feat(nextflow): lower boolean inputBinding flags

### DIFF
--- a/design_docs/sophios_nextflow_backend.md
+++ b/design_docs/sophios_nextflow_backend.md
@@ -140,6 +140,8 @@ Serialized IR declares a schema version and representation kind. Hydration valid
 
 Additive extensions — new typed token or segment kinds — bump the schema version. Serialization always writes the current version. Hydration accepts the current version plus earlier versions whose value spaces are strict subsets of the current model; every other version is rejected.
 
+Subset acceptance is enforced, not documentary: each additive token or segment kind declares the version that introduced it, and hydration rejects a payload that carries a kind newer than its declared `schema_version`. Version acceptance alone is not a compatibility claim — the promotion path compares rendered output byte-for-byte against stored source, so renderer output for previously representable models is the binding compatibility surface, and changing it invalidates existing artifact pairs regardless of the version number.
+
 ---
 
 ## 6. Semantic lowering contracts
@@ -148,7 +150,13 @@ Additive extensions — new typed token or segment kinds — bump the schema ver
 
 CWL command construction is normalized before rendering. Ordering follows the pinned CWL version, including defaults and tie-breaking. Command parts remain typed as literal data or interpolation references; quoting is decided per token or segment, never by scanning a completed string for `$`.
 
-**Boolean flags (approved Phase 2 lowering).** A non-optional `boolean` input with an `inputBinding` and no `valueFrom` lowers to a typed conditional flag token that references the input by name and carries a non-empty prefix. At runtime, `true` renders the shell-quoted prefix as exactly one argv word and `false` renders nothing; a boolean binding without a prefix contributes nothing for either value. Flag tokens are valid only in command token position — never in globs or stream targets — and only against `val` ports. `valueFrom` on a boolean binding and absent optional booleans keep their existing rejection states.
+**Boolean flags (approved Phase 2 lowering).** A `boolean` input with an `inputBinding` and no `valueFrom` lowers to a typed conditional flag token that references the input by name and carries a non-empty prefix. At runtime, `true` renders the shell-quoted prefix as exactly one argv word and `false` renders nothing; a boolean binding without a prefix contributes nothing for either value. Flag tokens are valid only in command token position — never in globs or stream targets — and only against `val` ports. An optional boolean lowers the same way when a value is present; an absent optional value keeps rejecting under the option-lowering rule above.
+
+The rendered flag is a conditional over its channel value, so the lowering is sound only when that value is a JSON boolean at runtime. Capability analysis therefore requires every input consumed by a flag token to resolve to a boolean-typed source, whether that source is a workflow input or a producing process output port. Truthiness of a staged path or of a string such as `"false"` must never be allowed to decide a flag.
+
+`valueFrom` on a boolean `inputBinding` is rejected. CWL evaluates `valueFrom` and then applies boolean flag semantics to the result, so a lowering would have to reproduce that ordering; until one is approved, the construct fails closed rather than emitting the prefix beside a rendered value.
+
+**Diagnostics and security for this lowering.** A rejected flag construct names the source path and the deferred capability, and independent findings aggregate like every other capability diagnostic. An empty prefix is a source error and is reported; an absent prefix is valid CWL and contributes nothing. The prefix is data, never syntax: it is emitted through the generated shell-quoting helper, so it reaches the process as exactly one argv word and cannot introduce shell operators, redirections, or command substitution.
 
 Shell operators exist only under an explicitly supported shell-mode lowering. `ShellCommandRequirement`, `shellQuote: false`, `InitialWorkDirRequirement`, and unapproved expression forms are rejected until that lowering exists.
 
@@ -244,7 +252,7 @@ The Phase 1 reader recognizes the generated DSL2 subset. Unknown content remains
 
 ### Phase 2 — Semantic expansion and composition
 
-Phase 2 may add executable scatter and nested workflows, absent-option lowering, File/array behavior, shell-mode command construction, `InitialWorkDirRequirement`, richer output capture and expression handling, and any required channel adapters.
+Phase 2 may add executable scatter and nested workflows, absent-option lowering, File/array behavior, command-construction expansion such as conditional flag tokens, shell-mode command construction, `InitialWorkDirRequirement`, richer output capture and expression handling, and any required channel adapters.
 
 Each addition requires a separate lowering decision, executable-model extension, compatibility plan, negative boundary tests, and focused real-Nextflow proof. Scatter methods, collection cardinality, empty collections, nested namespacing, subworkflow I/O, shell security, expression scope, and schema migration are resolved before implementation.
 

--- a/design_docs/sophios_nextflow_backend.md
+++ b/design_docs/sophios_nextflow_backend.md
@@ -138,6 +138,8 @@ Connection variants make boundary-to-boundary dangling edges unrepresentable. Ke
 
 Serialized IR declares a schema version and representation kind. Hydration validates all invariants. Schema evolution is backward-compatible or is accompanied by an explicit migration; it never relies on best-effort dictionary loading.
 
+Additive extensions — new typed token or segment kinds — bump the schema version. Serialization always writes the current version. Hydration accepts the current version plus earlier versions whose value spaces are strict subsets of the current model; every other version is rejected.
+
 ---
 
 ## 6. Semantic lowering contracts
@@ -145,6 +147,8 @@ Serialized IR declares a schema version and representation kind. Hydration valid
 ### Commands
 
 CWL command construction is normalized before rendering. Ordering follows the pinned CWL version, including defaults and tie-breaking. Command parts remain typed as literal data or interpolation references; quoting is decided per token or segment, never by scanning a completed string for `$`.
+
+**Boolean flags (approved Phase 2 lowering).** A non-optional `boolean` input with an `inputBinding` and no `valueFrom` lowers to a typed conditional flag token that references the input by name and carries a non-empty prefix. At runtime, `true` renders the shell-quoted prefix as exactly one argv word and `false` renders nothing; a boolean binding without a prefix contributes nothing for either value. Flag tokens are valid only in command token position — never in globs or stream targets — and only against `val` ports. `valueFrom` on a boolean binding and absent optional booleans keep their existing rejection states.
 
 Shell operators exist only under an explicitly supported shell-mode lowering. `ShellCommandRequirement`, `shellQuote: false`, `InitialWorkDirRequirement`, and unapproved expression forms are rejected until that lowering exists.
 
@@ -245,6 +249,10 @@ Phase 2 may add executable scatter and nested workflows, absent-option lowering,
 Each addition requires a separate lowering decision, executable-model extension, compatibility plan, negative boundary tests, and focused real-Nextflow proof. Scatter methods, collection cardinality, empty collections, nested namespacing, subworkflow I/O, shell security, expression scope, and schema migration are resolved before implementation.
 
 Phase 2 does not authorize arbitrary Groovy parsing.
+
+Approved Phase 2 lowerings to date:
+
+- Boolean `inputBinding` flags (§6, Commands).
 
 ### Phase 3 — Native inference, advanced execution, and service delivery
 

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -76,11 +76,19 @@ written from validated executable IR. Parsed source alone is never promoted by
 guessing shell or Groovy semantics; changed source, changed parameters, unknown
 content, and invalid or stale IR fail closed.
 
-## Phase 1 limits
+## Boolean flags
+
+A non-optional `boolean` input with an `inputBinding` prefix and no
+`valueFrom` becomes a real command-line flag: `true` contributes the prefix as
+exactly one argument and `false` contributes nothing. A boolean binding
+without a prefix contributes nothing for either value, matching CWL. Absent
+optional booleans still reject until option lowering is approved.
+
+## Current limits
 
 - Workflows must be flat and use `CommandLineTool`-equivalent processes.
-- Boolean `inputBinding` flag semantics and fractional CPU requirements reject
-  before lowering; they are not silently stringified or rounded.
+- Fractional CPU requirements reject before lowering; they are not silently
+  rounded.
 - Scatter is retained as opaque structure; executable scatter is deferred.
 - Nested workflows, arbitrary Groovy, channel operators, `when`, and `exec`
   blocks are not interpreted.

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -78,7 +78,7 @@ content, and invalid or stale IR fail closed.
 
 ## Boolean flags
 
-A non-optional `boolean` input with an `inputBinding` prefix and no
+A `boolean` input with an `inputBinding` prefix and no
 `valueFrom` becomes a real command-line flag: `true` contributes the prefix as
 exactly one argument and `false` contributes nothing. A boolean binding
 without a prefix contributes nothing for either value, matching CWL. Absent

--- a/src/sophios/api/python/nextflow.py
+++ b/src/sophios/api/python/nextflow.py
@@ -9,7 +9,9 @@ from sophios.input_output_nf import (
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
     NfCommand,
+    NfCommandToken,
     NfConnection,
+    NfFlag,
     NfInputReference,
     NfLiteral,
     NfPort,
@@ -36,7 +38,9 @@ from sophios.nf_reader import (
 __all__ = [
     "ExecutableNextflowWorkflow",
     "NfCommand",
+    "NfCommandToken",
     "NfConnection",
+    "NfFlag",
     "NfInputReference",
     "NfLiteral",
     "NfPort",

--- a/src/sophios/input_output_nf.py
+++ b/src/sophios/input_output_nf.py
@@ -10,6 +10,7 @@ from .nf_types import (
     ExecutableNextflowWorkflow,
     NF_SHELL_QUOTE_HELPER,
     NfConnection,
+    NfFlag,
     NfInputReference,
     NfLiteral,
     NfPort,
@@ -76,6 +77,14 @@ def _render_template(template: Any) -> str:
     return f"${{{NF_SHELL_QUOTE_HELPER}({_template_expression(template)})}}"
 
 
+def _render_command_token(token: Any) -> str:
+    """Render one argv token; flags collapse to nothing when their input is false."""
+    if isinstance(token, NfFlag):
+        quoted = f"{NF_SHELL_QUOTE_HELPER}({_groovy_literal(token.prefix)})"
+        return f"${{{token.name} ? {quoted} : ''}}"
+    return _render_template(token)
+
+
 def _render_glob(template: Any) -> str:
     if all(isinstance(segment, NfLiteral) for segment in template.segments):
         return _groovy_literal("".join(segment.value for segment in template.segments))
@@ -117,7 +126,7 @@ def _render_process(process: NfProcess) -> str:
         lines.extend(["", "    output:"])
         lines.extend(f"    {_process_output(port)}" for port in process.outputs)
 
-    command = " ".join(_render_template(token) for token in process.command.tokens)
+    command = " ".join(_render_command_token(token) for token in process.command.tokens)
     for operator, stream in (("<", process.command.stdin), (">", process.command.stdout), ("2>", process.command.stderr)):
         if stream is not None:
             command += f" {operator} {_render_template(stream)}"

--- a/src/sophios/nf_types.py
+++ b/src/sophios/nf_types.py
@@ -747,6 +747,9 @@ class ExecutableNextflowWorkflow:
     # Earlier versions whose value space is a strict subset of the current
     # model hydrate unchanged; serialization always writes SCHEMA_VERSION.
     SUPPORTED_SCHEMA_VERSIONS: ClassVar[frozenset[int]] = frozenset({2, 3})
+    # Each additive token or segment kind declares the version that
+    # introduced it, so the subset property is enforced rather than assumed.
+    KIND_SCHEMA_VERSIONS: ClassVar[Mapping[str, int]] = MappingProxyType({"flag": 3})
     REPRESENTATION_KIND: ClassVar[str] = "executable"
 
     name: str
@@ -938,6 +941,7 @@ class ExecutableNextflowWorkflow:
             raise ValueError(
                 f"unsupported executable Nextflow schema version {item['schema_version']!r}"
             )
+        cls._reject_newer_kinds(item, declared=item["schema_version"])
         if item["representation_kind"] != cls.REPRESENTATION_KIND:
             raise ValueError(
                 f"unsupported Nextflow representation kind {item['representation_kind']!r}"
@@ -954,6 +958,25 @@ class ExecutableNextflowWorkflow:
                 raise TypeError(
                     "ExecutableNextflowWorkflow processes and connections must be lists"
                 )
+
+    @classmethod
+    def _reject_newer_kinds(cls, value: Any, *, declared: int) -> None:
+        """Reject a payload carrying a kind newer than its declared version."""
+        match value:
+            case Mapping() as mapping:
+                introduced = cls.KIND_SCHEMA_VERSIONS.get(str(mapping.get("kind")))
+                if introduced is not None and declared < introduced:
+                    raise ValueError(
+                        f"{mapping['kind']!r} requires executable Nextflow schema version "
+                        f"{introduced}, but the payload declares schema version {declared}"
+                    )
+                for item in mapping.values():
+                    cls._reject_newer_kinds(item, declared=declared)
+            case list() as items:
+                for item in items:
+                    cls._reject_newer_kinds(item, declared=declared)
+            case _:
+                pass
 
     @classmethod
     def from_json(cls, value: str) -> Self:

--- a/src/sophios/nf_types.py
+++ b/src/sophios/nf_types.py
@@ -218,17 +218,54 @@ class NfTemplate:
 
 
 @dataclass(frozen=True, slots=True)
+class NfFlag:
+    """Conditional command-line flag contributed by a boolean input.
+
+    Renders the prefix as exactly one argv word when the referenced input is
+    true, and nothing when it is false. Valid only in command token position.
+    """
+
+    name: str
+    prefix: str
+
+    def __post_init__(self) -> None:
+        _validate_ir_identifier(self.name, field_name="flag input reference")
+        if not isinstance(self.prefix, str) or not self.prefix.strip():
+            raise ValueError("flag prefix must be a non-empty string")
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-compatible representation.
+
+        Returns:
+            dict[str, str]: The token as ``{"kind": "flag", "name": ...,
+                "prefix": ...}``.
+        """
+        return {"kind": "flag", "name": self.name, "prefix": self.prefix}
+
+
+NfCommandToken = NfTemplate | NfFlag
+
+
+def _command_token_from_dict(value: Mapping[str, Any]) -> NfCommandToken:
+    item = _mapping(value, type_name="NfCommandToken")
+    if item.get("kind") != "flag":
+        return NfTemplate.from_dict(item)
+    _check_fields(item, type_name="NfFlag", required={"kind", "name", "prefix"})
+    return NfFlag(item["name"], item["prefix"])
+
+
+@dataclass(frozen=True, slots=True)
 class NfCommand:
     """Typed argv and approved stream redirections for one process."""
 
-    tokens: Sequence[NfTemplate]
+    tokens: Sequence[NfCommandToken]
     stdin: NfTemplate | None = None
     stdout: NfTemplate | None = None
     stderr: NfTemplate | None = None
 
     def __post_init__(self) -> None:
         tokens = tuple(self.tokens)
-        if not tokens or not all(isinstance(token, NfTemplate) for token in tokens):
+        if not tokens or not all(isinstance(token, (NfTemplate, NfFlag)) for token in tokens):
             raise ValueError("command must contain at least one typed token")
         object.__setattr__(self, "tokens", tokens)
         for name in ("stdin", "stdout", "stderr"):
@@ -273,7 +310,7 @@ class NfCommand:
             return None if raw is None else NfTemplate.from_dict(raw)
 
         return cls(
-            tuple(NfTemplate.from_dict(token) for token in item["tokens"]),
+            tuple(_command_token_from_dict(token) for token in item["tokens"]),
             hydrate(item["stdin"]), hydrate(item["stdout"]), hydrate(item["stderr"]),
         )
 
@@ -444,12 +481,13 @@ class NfProcess:
         if not isinstance(self.command, NfCommand):
             raise TypeError("process command must be an NfCommand")
         input_names = {port.name for port in inputs}
+        flag_names = {token.name for token in self.command.tokens if isinstance(token, NfFlag)}
         templates = [
-            *self.command.tokens,
+            *(token for token in self.command.tokens if isinstance(token, NfTemplate)),
             *(template for template in (self.command.stdin, self.command.stdout, self.command.stderr) if template),
             *(port.glob for port in outputs if port.glob),
         ]
-        references = {
+        references = flag_names | {
             segment.name
             for template in templates
             for segment in template.segments
@@ -458,6 +496,12 @@ class NfProcess:
         if unknown := references - input_names:
             raise ValueError(
                 f"process {self.name!r} templates reference unknown inputs: {', '.join(sorted(unknown))}"
+            )
+        value_names = {port.name for port in inputs if port.qualifier == "val"}
+        if invalid := flag_names - value_names:
+            raise ValueError(
+                f"process {self.name!r} flag tokens must reference val inputs: "
+                f"{', '.join(sorted(invalid))}"
             )
         match self.container:
             case None:
@@ -699,7 +743,10 @@ def _connection_from_dict(value: Mapping[str, Any]) -> NfConnection:
 class ExecutableNextflowWorkflow:
     """Closed, immutable, versioned executable representation of a DSL2 workflow."""
 
-    SCHEMA_VERSION: ClassVar[int] = 2
+    SCHEMA_VERSION: ClassVar[int] = 3
+    # Earlier versions whose value space is a strict subset of the current
+    # model hydrate unchanged; serialization always writes SCHEMA_VERSION.
+    SUPPORTED_SCHEMA_VERSIONS: ClassVar[frozenset[int]] = frozenset({2, 3})
     REPRESENTATION_KIND: ClassVar[str] = "executable"
 
     name: str
@@ -887,7 +934,7 @@ class ExecutableNextflowWorkflow:
                 "params",
             },
         )
-        if item["schema_version"] != cls.SCHEMA_VERSION:
+        if item["schema_version"] not in cls.SUPPORTED_SCHEMA_VERSIONS:
             raise ValueError(
                 f"unsupported executable Nextflow schema version {item['schema_version']!r}"
             )

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -12,7 +12,9 @@ from .nf_types import (
     ExecutableNextflowWorkflow,
     NF_INTERNAL_IDENTIFIERS,
     NfCommand,
+    NfCommandToken,
     NfConnection,
+    NfFlag,
     NfInputReference,
     NfLiteral,
     NfPort,
@@ -253,8 +255,8 @@ def _argument_items(arguments: list[Any]) -> list[tuple[tuple[int, int, int], tu
 
 def _input_binding_items(
     inputs: Mapping[str, Any],
-) -> list[tuple[tuple[int, int, str], tuple[NfTemplate, ...]]]:
-    items: list[tuple[tuple[int, int, str], tuple[NfTemplate, ...]]] = []
+) -> list[tuple[tuple[int, int, str], tuple[NfCommandToken, ...]]]:
+    items: list[tuple[tuple[int, int, str], tuple[NfCommandToken, ...]]] = []
     for raw_name, definition in inputs.items():
         input_definition = _as_mapping(definition, error=f"CWL input {raw_name!r} must be a mapping")
         match input_definition.get("inputBinding"):
@@ -266,16 +268,28 @@ def _input_binding_items(
                 raise ValueError(f"CWL inputBinding for {raw_name!r} must be a mapping")
         name = _identifier(raw_name, context="input binding name")
         value_from = binding.get("valueFrom")
+        position = _position(binding.get("position"), default=0)
+        if value_from is None and _required_type(input_definition.get("type")) == "boolean":
+            # CWL boolean bindings contribute their prefix, or nothing at all
+            # when the flag is false or no prefix is declared.
+            match binding.get("prefix"):
+                case None:
+                    continue
+                case str() as prefix if prefix:
+                    items.append(((position, 1, str(raw_name)), (NfFlag(name, prefix),)))
+                    continue
+                case _:
+                    raise ValueError(f"CWL command prefix for {raw_name!r} must be a non-empty string")
         value = (
             _template(value_from, context=f"CWL input {raw_name!r} valueFrom")
             if value_from is not None else NfTemplate((NfInputReference(name),))
         )
         tokens = _binding_tokens(binding.get("prefix"), value, separate=binding.get("separate", True))
-        items.append(((_position(binding.get("position"), default=0), 1, str(raw_name)), tokens))
+        items.append(((position, 1, str(raw_name)), tokens))
     return items
 
 
-def _command_items(tool: Mapping[str, Any]) -> tuple[NfTemplate, ...]:
+def _command_items(tool: Mapping[str, Any]) -> tuple[NfCommandToken, ...]:
     arguments = _as_list(tool.get("arguments", []), error="CommandLineTool arguments must be a list")
     inputs = _as_mapping(tool.get("inputs", {}), error="CommandLineTool inputs must be a mapping")
     ordered = sorted([*_argument_items(arguments), *_input_binding_items(inputs)])
@@ -284,7 +298,7 @@ def _command_items(tool: Mapping[str, Any]) -> tuple[NfTemplate, ...]:
 
 def _command(tool: Mapping[str, Any]) -> NfCommand:
     base_command = tool.get("baseCommand")
-    tokens: list[NfTemplate] = []
+    tokens: list[NfCommandToken] = []
     match base_command:
         case str() as command if command:
             tokens.append(_template(command, context="CWL baseCommand"))
@@ -715,14 +729,6 @@ def _tool_capability_findings(
                 if binding.get("shellQuote") is False:
                     findings.append(
                         f"{input_binding_path}.shellQuote: shellQuote false is deferred to Phase 2"
-                    )
-                if (
-                    _required_type(raw_definition.get("type")) == "boolean"
-                    and binding.get("valueFrom") is None
-                ):
-                    findings.append(
-                        f"{input_binding_path}: boolean inputBinding flag semantics are "
-                        "deferred to Phase 2"
                     )
         case _:
             pass

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -226,6 +226,9 @@ def _position(value: Any, *, default: int) -> int:
 def _binding_tokens(prefix: Any, value: NfTemplate, *, separate: Any = True) -> tuple[NfTemplate, ...]:
     match prefix:
         case None:
+            if separate is not None and separate is not True:
+                # cwltool raises for separate without prefix, type-independently.
+                raise ValueError("CWL separate cannot be specified without a prefix")
             return (value,)
         case str() as text:
             prefix_template = _template(text, context="CWL command prefix")
@@ -274,6 +277,8 @@ def _input_binding_items(
             # when the flag is false or no prefix is declared.
             match binding.get("prefix"):
                 case None:
+                    if binding.get("separate") is not None:
+                        raise ValueError("CWL separate cannot be specified without a prefix")
                     continue
                 case str() as prefix if prefix:
                     items.append(((position, 1, str(raw_name)), (NfFlag(name, prefix),)))
@@ -315,8 +320,9 @@ def _command(tool: Mapping[str, Any]) -> NfCommand:
             raise ValueError("CommandLineTool baseCommand must be a string or list of strings")
 
     tokens.extend(_command_items(tool))
-    if not tokens:
-        tokens.append(_template("true", context="empty CWL command"))
+    if not any(isinstance(token, NfTemplate) for token in tokens):
+        # A command made only of conditional flags has nothing to execute.
+        tokens.insert(0, _template("true", context="empty CWL command"))
 
     def stream(name: str) -> NfTemplate | None:
         return None if tool.get(name) is None else _template(tool[name], context=f"CWL {name}")

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -730,6 +730,15 @@ def _tool_capability_findings(
                     findings.append(
                         f"{input_binding_path}.shellQuote: shellQuote false is deferred to Phase 2"
                     )
+                if (
+                    _required_type(raw_definition.get("type")) == "boolean"
+                    and binding.get("valueFrom") is not None
+                ):
+                    findings.append(
+                        f"{input_binding_path}.valueFrom: valueFrom on a boolean inputBinding is "
+                        "deferred to Phase 2; CWL applies boolean flag semantics to the "
+                        "valueFrom result, which has no approved lowering"
+                    )
         case _:
             pass
 
@@ -980,6 +989,98 @@ def _absent_optional_findings(
                     else "resolves to an absent required value"
                 )
                 findings.append(f"steps[{step_index}].run.inputs.{raw_name}: {detail}")
+    return findings
+
+
+def _is_flag_binding(definition: Mapping[str, Any]) -> bool:
+    """Return whether a tool input will lower to a conditional flag token."""
+    match definition.get("inputBinding"):
+        case Mapping() as binding:
+            pass
+        case _:
+            return False
+    return (
+        _required_type(definition.get("type")) == "boolean"
+        and binding.get("valueFrom") is None
+        and isinstance(binding.get("prefix"), str)
+        and bool(binding.get("prefix"))
+    )
+
+
+def _source_types(
+    workflow: Mapping[str, Any],
+    steps: list[Mapping[str, Any]],
+    sub_trees: list[Any],
+) -> dict[str, Any]:
+    """Map every wireable source name to the CWL type it carries."""
+    types: dict[str, Any] = {}
+    match workflow.get("inputs", {}):
+        case Mapping() as inputs:
+            for raw_name, definition in inputs.items():
+                declared = definition.get("type") if isinstance(definition, Mapping) else definition
+                types[str(raw_name)] = declared
+        case _:
+            pass
+    for step, child in zip(steps, sub_trees, strict=True):
+        match step.get("id"), child:
+            case str() as raw_id, RoseTree(data=NodeData(compiled_cwl=Mapping() as tool)):
+                pass
+            case _:
+                continue
+        outputs = tool.get("outputs", {})
+        if not isinstance(outputs, Mapping):
+            continue
+        for raw_port, definition in outputs.items():
+            declared = definition.get("type") if isinstance(definition, Mapping) else definition
+            for step_key in (raw_id, raw_id.rsplit("#", maxsplit=1)[-1]):
+                types[f"{step_key}/{raw_port}"] = declared
+    return types
+
+
+def _flag_source_findings(
+    workflow: Mapping[str, Any],
+    steps: list[Mapping[str, Any]],
+    sub_trees: list[Any],
+) -> list[str]:
+    """Require a boolean source for every input lowered to a flag token.
+
+    A flag renders as a Groovy ternary over its channel value, so a
+    non-boolean source would let Groovy truthiness decide the flag: a staged
+    path is always truthy and the strings ``"false"`` and ``"0"`` are too.
+    """
+    source_types = _source_types(workflow, steps, sub_trees)
+    findings: list[str] = []
+    for step_index, (step, child) in enumerate(zip(steps, sub_trees, strict=True)):
+        match child:
+            case RoseTree(data=NodeData(compiled_cwl=Mapping() as tool)):
+                pass
+            case _:
+                continue
+        tool_inputs = tool.get("inputs", {})
+        step_inputs = step.get("in", {})
+        if not isinstance(tool_inputs, Mapping) or not isinstance(step_inputs, Mapping):
+            continue
+        for raw_name, definition in tool_inputs.items():
+            if not isinstance(definition, Mapping) or not _is_flag_binding(definition):
+                continue
+            raw_source = step_inputs.get(raw_name)
+            if raw_source is None:
+                continue
+            try:
+                sources = _source_values(
+                    raw_source,
+                    context=f"step input {step_index}.{raw_name}",
+                )
+            except ValueError:
+                continue
+            for source in sources:
+                declared = source_types.get(source, source_types.get(str(source)))
+                if declared is not None and _required_type(declared) == "boolean":
+                    continue
+                findings.append(
+                    f"steps[{step_index}].in.{raw_name}: a boolean flag input requires a "
+                    f"boolean source; {source!r} declares {declared!r}"
+                )
     return findings
 
 
@@ -1283,6 +1384,7 @@ def cwl_rosetree_to_nextflow(rose_tree: RoseTree) -> ExecutableNextflowWorkflow:
     ]
     findings.extend(_workflow_capability_findings(workflow, node_data, steps))
     findings.extend(_absent_optional_findings(workflow, node_data, steps, sub_trees))
+    findings.extend(_flag_source_findings(workflow, steps, sub_trees))
     findings.extend(_container_policy_findings(sub_trees))
     _raise_capability_findings(findings)
     processes = [

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -226,7 +226,7 @@ def _position(value: Any, *, default: int) -> int:
 def _binding_tokens(prefix: Any, value: NfTemplate, *, separate: Any = True) -> tuple[NfTemplate, ...]:
     match prefix:
         case None:
-            if separate is not None and separate is not True:
+            if not separate:
                 # cwltool raises for separate without prefix, type-independently.
                 raise ValueError("CWL separate cannot be specified without a prefix")
             return (value,)
@@ -277,10 +277,10 @@ def _input_binding_items(
             # when the flag is false or no prefix is declared.
             match binding.get("prefix"):
                 case None:
-                    if binding.get("separate") is not None:
+                    if not binding.get("separate", True):
                         raise ValueError("CWL separate cannot be specified without a prefix")
                     continue
-                case str() as prefix if prefix:
+                case str() as prefix if prefix.strip():
                     items.append(((position, 1, str(raw_name)), (NfFlag(name, prefix),)))
                     continue
                 case _:
@@ -1078,7 +1078,15 @@ def _flag_source_findings(
                     context=f"step input {step_index}.{raw_name}",
                 )
             except ValueError:
-                continue
+                if isinstance(raw_source, Mapping) and ("default" in raw_source or "source" in raw_source):
+                    # {"default": ...} is rejected by the absent-optional
+                    # findings pass; {"source": ..., <extra>} is rejected by
+                    # _source_values itself during lowering. Neither needs a
+                    # boolean-source finding on top. Any other shape that
+                    # reaches here is unrecognized and must not be silently
+                    # exempted from the boolean-source requirement.
+                    continue
+                raise
             for source in sources:
                 declared = source_types.get(source, source_types.get(str(source)))
                 if declared is not None and _required_type(declared) == "boolean":

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -1078,13 +1078,11 @@ def _flag_source_findings(
                     context=f"step input {step_index}.{raw_name}",
                 )
             except ValueError:
-                if isinstance(raw_source, Mapping) and ("default" in raw_source or "source" in raw_source):
-                    # {"default": ...} is rejected by the absent-optional
-                    # findings pass; {"source": ..., <extra>} is rejected by
-                    # _source_values itself during lowering. Neither needs a
-                    # boolean-source finding on top. Any other shape that
-                    # reaches here is unrecognized and must not be silently
-                    # exempted from the boolean-source requirement.
+                if isinstance(raw_source, Mapping):
+                    # Every mapping shape _source_values rejects is already
+                    # reported, by path, by the unconsumed-fields pass. A
+                    # non-mapping shape is genuinely unrecognized and must not
+                    # be silently exempted from the boolean-source requirement.
                     continue
                 raise
             for source in sources:

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -104,6 +104,96 @@ def test_accepts_boolean_flag_bindings_for_both_values(value: bool) -> None:
 
 
 @pytest.mark.fast
+@pytest.mark.parametrize("value", [False, True])
+def test_rejects_value_from_on_a_boolean_binding(value: bool) -> None:
+    """CWL applies boolean semantics after valueFrom; Phase 2 has no such lowering."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {
+                    "position": 1,
+                    "prefix": "--verbose",
+                    "valueFrom": "$(inputs.verbose)",
+                },
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": value},
+    )
+
+    with pytest.raises(ValueError, match=r"valueFrom.*boolean"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_rejects_file_output_wired_into_a_boolean_flag() -> None:
+    """A staged path is always truthy in Groovy, so the flag would never clear."""
+    producer = tool("MAKE", outputs={"out": {"type": "File", "outputBinding": {"glob": "f.txt"}}})
+    consumer = tool(
+        "SORT",
+        inputs={"reverse": {"type": "boolean", "inputBinding": {"position": 1, "prefix": "-r"}}},
+    )
+    rose = synthetic_rose(
+        workflow_doc([
+            step("MAKE", out=["out"]),
+            step("SORT", **{"in": {"reverse": "MAKE/out"}}),
+        ]),
+        [producer, consumer],
+    )
+
+    with pytest.raises(ValueError, match=r"reverse.*boolean source"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("supplied", ["false", "0", ""])
+def test_rejects_string_source_wired_into_a_boolean_flag(supplied: str) -> None:
+    """Groovy truthiness of a string would decide the flag, not the source value."""
+    consumer = tool(
+        "SORT",
+        inputs={"reverse": {"type": "boolean", "inputBinding": {"position": 1, "prefix": "-r"}}},
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("SORT", **{"in": {"reverse": "flagval"}})],
+            inputs={"flagval": {"type": "string"}},
+        ),
+        [consumer],
+        workflow_inputs={"flagval": supplied},
+    )
+
+    with pytest.raises(ValueError, match=r"reverse.*boolean source"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_accepts_a_boolean_source_wired_into_a_boolean_flag() -> None:
+    """The supported wiring stays supported: boolean source into a flag input."""
+    consumer = tool(
+        "SORT",
+        inputs={"reverse": {"type": "boolean", "inputBinding": {"position": 1, "prefix": "-r"}}},
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("SORT", **{"in": {"reverse": "flagval"}})],
+            inputs={"flagval": {"type": "boolean"}},
+        ),
+        [consumer],
+        workflow_inputs={"flagval": False},
+    )
+
+    assert cwl_rosetree_to_nextflow(rose).params == {"flagval": False}
+
+
+@pytest.mark.fast
 def test_rejects_absent_optional_boolean_flag() -> None:
     flags = tool(
         "FLAGS",

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -81,7 +81,7 @@ def test_rejects_every_unconsumed_tool_field_before_lowering() -> None:
 
 @pytest.mark.fast
 @pytest.mark.parametrize("value", [False, True])
-def test_rejects_unlowered_boolean_input_binding_semantics(value: bool) -> None:
+def test_accepts_boolean_flag_bindings_for_both_values(value: bool) -> None:
     flags = tool(
         "FLAGS",
         inputs={
@@ -100,7 +100,30 @@ def test_rejects_unlowered_boolean_input_binding_semantics(value: bool) -> None:
         workflow_inputs={"verbose": value},
     )
 
-    with pytest.raises(ValueError, match="boolean inputBinding flag semantics"):
+    assert cwl_rosetree_to_nextflow(rose).params == {"verbose": value}
+
+
+@pytest.mark.fast
+def test_rejects_absent_optional_boolean_flag() -> None:
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": ["null", "boolean"],
+                "inputBinding": {"position": 1, "prefix": "--verbose"},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": ["null", "boolean"]}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": None},
+    )
+
+    with pytest.raises(ValueError, match="absent optional"):
         cwl_rosetree_to_nextflow(rose)
 
 

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -637,6 +637,127 @@ def test_rejects_separate_without_a_prefix() -> None:
 
 
 @pytest.mark.fast
+def test_accepts_separate_true_without_a_prefix_on_a_boolean_binding() -> None:
+    """cwltool accepts separate: true without a prefix; only a falsy separate rejects."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "separate": True},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": True},
+    )
+
+    assert cwl_rosetree_to_nextflow(rose).params == {"verbose": True}
+
+
+@pytest.mark.fast
+def test_rejects_separate_null_without_a_prefix_on_a_boolean_binding() -> None:
+    """cwltool's own .get("separate", True) only defaults an absent key; separate: null still rejects."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "separate": None},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": True},
+    )
+
+    with pytest.raises(ValueError, match="separate cannot be specified without a prefix"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_rejects_separate_null_without_a_prefix_on_a_string_binding() -> None:
+    """The general _binding_tokens path rejects separate: null the same way the boolean path does."""
+    echo = tool(
+        "ECHO",
+        inputs={
+            "message": {
+                "type": "string",
+                "inputBinding": {"position": 1, "separate": None},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("ECHO", **{"in": {"message": "message"}})],
+            inputs={"message": {"type": "string"}},
+        ),
+        [echo],
+        workflow_inputs={"message": "hi"},
+    )
+
+    with pytest.raises(ValueError, match="separate cannot be specified without a prefix"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_rejects_whitespace_only_prefix_on_a_boolean_binding() -> None:
+    """A blank prefix must hit the named capability diagnostic, not NfFlag's own invariant."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "prefix": "   "},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": True},
+    )
+
+    with pytest.raises(ValueError, match="CWL command prefix for 'verbose' must be a non-empty string"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("raw_source", [[], 42])
+def test_rejects_a_flag_input_wired_to_an_unrecognized_source_shape(raw_source: Any) -> None:
+    """A shape _source_values cannot read must still fail closed, not silently skip the boolean-source check."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "prefix": "--verbose"},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc([step("FLAGS", **{"in": {"verbose": raw_source}})]),
+        [flags],
+    )
+
+    with pytest.raises(ValueError):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
 def test_a_command_of_only_flags_still_runs_a_program() -> None:
     """A flag-only argv would render an empty script that silently exits zero."""
     flags = tool(

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -10,7 +10,7 @@ import pytest
 
 from sophios.api.python.workflow import CompiledWorkflow
 from sophios.input_output_nf import render_nextflow
-from sophios.nf_types import NfResources
+from sophios.nf_types import NfFlag, NfLiteral, NfResources, NfTemplate
 from sophios.utils_nf import cwl_rosetree_to_nextflow
 from sophios.wic_types import RoseTree
 
@@ -609,3 +609,56 @@ def test_rejects_unknown_connection_source() -> None:
     )
     with pytest.raises(ValueError, match="unknown source process"):
         cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_rejects_separate_without_a_prefix() -> None:
+    """cwltool raises for separate without prefix, so the backend must not accept it."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "separate": False},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": True},
+    )
+
+    with pytest.raises(ValueError, match="separate cannot be specified without a prefix"):
+        cwl_rosetree_to_nextflow(rose)
+
+
+@pytest.mark.fast
+def test_a_command_of_only_flags_still_runs_a_program() -> None:
+    """A flag-only argv would render an empty script that silently exits zero."""
+    flags = tool(
+        "FLAGS",
+        inputs={
+            "verbose": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "prefix": "--verbose"},
+            }
+        },
+        baseCommand=None,
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("FLAGS", **{"in": {"verbose": "verbose"}})],
+            inputs={"verbose": {"type": "boolean"}},
+        ),
+        [flags],
+        workflow_inputs={"verbose": True},
+    )
+
+    tokens = cwl_rosetree_to_nextflow(rose).processes[0].command.tokens
+
+    assert tokens[0] == NfTemplate((NfLiteral("true"),))
+    assert tokens[1] == NfFlag("verbose", "--verbose")

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -175,6 +175,17 @@ def test_flag_requires_a_non_empty_prefix(prefix: str) -> None:
 
 
 @pytest.mark.fast
+def test_public_module_exports_flag_and_command_token() -> None:
+    from sophios.api.python import nextflow
+    from sophios.nf_types import NfCommandToken
+
+    assert nextflow.NfFlag is NfFlag
+    assert nextflow.NfCommandToken is NfCommandToken
+    assert "NfFlag" in nextflow.__all__
+    assert "NfCommandToken" in nextflow.__all__
+
+
+@pytest.mark.fast
 def test_flag_must_reference_a_declared_value_input() -> None:
     command = NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r")))
     with pytest.raises(ValueError, match="unknown inputs"):

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -10,6 +10,8 @@ import pytest
 from sophios.nf_symbols import is_nextflow_identifier, normalize_nextflow_identifier
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfCommand,
+    NfFlag,
     NfLiteral,
     NfPort,
     NfProcess,
@@ -66,14 +68,14 @@ def test_executable_schema_declares_version_and_kind() -> None:
     workflow = ExecutableNextflowWorkflow("wf", [], [], {})
     payload = workflow.to_dict()
 
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     assert payload["representation_kind"] == "executable"
 
     payload["schema_version"] = 1
     with pytest.raises(ValueError, match="schema version"):
         ExecutableNextflowWorkflow.from_dict(payload)
 
-    payload["schema_version"] = 2
+    payload["schema_version"] = 3
     payload["representation_kind"] = "structural"
     with pytest.raises(ValueError, match="representation kind"):
         ExecutableNextflowWorkflow.from_dict(payload)
@@ -147,6 +149,60 @@ def test_uses_nextflow_identifier_symbols() -> None:
 def test_rejects_qualifiers_without_an_approved_lowering(qualifier: str) -> None:
     with pytest.raises(ValueError, match="qualifier"):
         NfPort("reads", qualifier)
+
+
+@pytest.mark.fast
+def test_flag_token_survives_hydration() -> None:
+    process = NfProcess(
+        "SORT",
+        [NfPort("reverse", "val")],
+        [output_port("result", "sorted.txt")],
+        NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r"))),
+    )
+    assert NfProcess.from_dict(process.to_dict()) == process
+    assert process.command.tokens[1].to_dict() == {
+        "kind": "flag",
+        "name": "reverse",
+        "prefix": "-r",
+    }
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("prefix", ["", "   "])
+def test_flag_requires_a_non_empty_prefix(prefix: str) -> None:
+    with pytest.raises(ValueError, match="prefix"):
+        NfFlag("reverse", prefix)
+
+
+@pytest.mark.fast
+def test_flag_must_reference_a_declared_value_input() -> None:
+    command = NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r")))
+    with pytest.raises(ValueError, match="unknown inputs"):
+        NfProcess("SORT", [], [], command)
+    with pytest.raises(ValueError, match="flag.*val"):
+        NfProcess("SORT", [NfPort("reverse", "path")], [], command)
+
+
+@pytest.mark.fast
+def test_flags_are_unrepresentable_outside_command_position() -> None:
+    with pytest.raises(TypeError, match="typed literal or input references"):
+        NfTemplate((cast(Any, NfFlag("reverse", "-r")),))
+
+
+@pytest.mark.fast
+def test_hydration_accepts_earlier_subset_schema_versions() -> None:
+    payload = ExecutableNextflowWorkflow(
+        "wf", [NfProcess("P", [], [], command("true"))], [], {}
+    ).to_dict()
+    assert payload["schema_version"] == 3
+
+    payload["schema_version"] = 2
+    assert ExecutableNextflowWorkflow.from_dict(payload).to_dict()["schema_version"] == 3
+
+    for unsupported in (1, 4):
+        payload["schema_version"] = unsupported
+        with pytest.raises(ValueError, match="schema version"):
+            ExecutableNextflowWorkflow.from_dict(payload)
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -206,6 +206,28 @@ def test_hydration_accepts_earlier_subset_schema_versions() -> None:
 
 
 @pytest.mark.fast
+def test_hydration_rejects_a_kind_newer_than_its_declared_version() -> None:
+    """A version is a claim about the value space, so it has to be enforced."""
+    payload = ExecutableNextflowWorkflow(
+        "wf",
+        [NfProcess(
+            "SORT",
+            [NfPort("reverse", "val")],
+            [],
+            NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r"))),
+        )],
+        [NfWorkflowInputConnection("reverse", "SORT", "reverse")],
+        {"reverse": True},
+    ).to_dict()
+
+    assert ExecutableNextflowWorkflow.from_dict(payload).to_dict() == payload
+
+    payload["schema_version"] = 2
+    with pytest.raises(ValueError, match="flag.*schema version 2"):
+        ExecutableNextflowWorkflow.from_dict(payload)
+
+
+@pytest.mark.fast
 def test_rejects_duplicate_process_names() -> None:
     process = NfProcess("P", [], [], command("true"))
     with pytest.raises(ValueError, match="duplicate process"):

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -11,6 +11,7 @@ from sophios.nf_symbols import is_nextflow_identifier, normalize_nextflow_identi
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
     NfCommand,
+    NfCommandToken,
     NfFlag,
     NfLiteral,
     NfPort,
@@ -177,7 +178,6 @@ def test_flag_requires_a_non_empty_prefix(prefix: str) -> None:
 @pytest.mark.fast
 def test_public_module_exports_flag_and_command_token() -> None:
     from sophios.api.python import nextflow
-    from sophios.nf_types import NfCommandToken
 
     assert nextflow.NfFlag is NfFlag
     assert nextflow.NfCommandToken is NfCommandToken
@@ -187,11 +187,11 @@ def test_public_module_exports_flag_and_command_token() -> None:
 
 @pytest.mark.fast
 def test_flag_must_reference_a_declared_value_input() -> None:
-    command = NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r")))
+    flag_command = NfCommand((NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r")))
     with pytest.raises(ValueError, match="unknown inputs"):
-        NfProcess("SORT", [], [], command)
+        NfProcess("SORT", [], [], flag_command)
     with pytest.raises(ValueError, match="flag.*val"):
-        NfProcess("SORT", [NfPort("reverse", "path")], [], command)
+        NfProcess("SORT", [NfPort("reverse", "path")], [], flag_command)
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_lowering.py
+++ b/tests/core/nextflow/test_lowering.py
@@ -10,6 +10,7 @@ import pytest
 from sophios import inference
 from sophios.input_output_nf import render_nextflow
 from sophios.nf_types import (
+    NfFlag,
     NfLiteral,
     NfResources,
     NfTemplate,
@@ -93,6 +94,52 @@ def test_composes_command_arguments_bindings_and_redirects() -> None:
     assert "> ${__sophios_shell_quote_9f72e('stdout.txt')}" in command_line
     assert "2> ${__sophios_shell_quote_9f72e('stderr.txt')}" in command_line
     assert process.outputs[0].glob == NfTemplate((NfLiteral("stdout.txt"),))
+
+
+@pytest.mark.fast
+def test_boolean_flag_lowers_to_a_conditional_flag_token() -> None:
+    sort_tool = tool(
+        "SORT",
+        inputs={
+            "reverse": {
+                "type": "boolean",
+                "inputBinding": {"position": 1, "prefix": "-r"},
+            }
+        },
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("SORT", **{"in": {"reverse": "reverse"}})],
+            inputs={"reverse": {"type": "boolean"}},
+        ),
+        [sort_tool],
+        workflow_inputs={"reverse": True},
+    )
+
+    command = cwl_rosetree_to_nextflow(rose).processes[0].command
+
+    assert command.tokens[1] == NfFlag("reverse", "-r")
+
+
+@pytest.mark.fast
+def test_boolean_binding_without_a_prefix_contributes_no_token() -> None:
+    sort_tool = tool(
+        "SORT",
+        inputs={"reverse": {"type": "boolean", "inputBinding": {"position": 1}}},
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("SORT", **{"in": {"reverse": "reverse"}})],
+            inputs={"reverse": {"type": "boolean"}},
+        ),
+        [sort_tool],
+        workflow_inputs={"reverse": True},
+    )
+
+    command = cwl_rosetree_to_nextflow(rose).processes[0].command
+
+    assert [token for token in command.tokens if isinstance(token, NfFlag)] == []
+    assert len(command.tokens) == 1
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_lowering.py
+++ b/tests/core/nextflow/test_lowering.py
@@ -11,6 +11,7 @@ from sophios import inference
 from sophios.input_output_nf import render_nextflow
 from sophios.nf_types import (
     NfFlag,
+    NfInputReference,
     NfLiteral,
     NfResources,
     NfTemplate,
@@ -119,6 +120,37 @@ def test_boolean_flag_lowers_to_a_conditional_flag_token() -> None:
     command = cwl_rosetree_to_nextflow(rose).processes[0].command
 
     assert command.tokens[1] == NfFlag("reverse", "-r")
+
+
+@pytest.mark.fast
+def test_flag_tokens_take_their_cwl_position_among_other_bindings() -> None:
+    """A flag is ordered by position like any other binding, not appended."""
+    sort_tool = tool(
+        "SORT",
+        inputs={
+            "source": {"type": "File", "inputBinding": {"position": 3}},
+            "reverse": {"type": "boolean", "inputBinding": {"position": 2, "prefix": "-r"}},
+        },
+        arguments=[{"position": 1, "valueFrom": "--stable"}],
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("SORT", **{"in": {"source": "source", "reverse": "reverse"}})],
+            inputs={"source": {"type": "File"}, "reverse": {"type": "boolean"}},
+        ),
+        [sort_tool],
+        workflow_inputs={
+            "source": {"class": "File", "path": "in.txt"},
+            "reverse": True,
+        },
+    )
+
+    tokens = cwl_rosetree_to_nextflow(rose).processes[0].command.tokens
+
+    assert tokens[0] == NfTemplate((NfLiteral("SORT"),))
+    assert tokens[1] == NfTemplate((NfLiteral("--stable"),))
+    assert tokens[2] == NfFlag("reverse", "-r")
+    assert tokens[3] == NfTemplate((NfInputReference("source"),))
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_properties.py
+++ b/tests/core/nextflow/test_properties.py
@@ -246,14 +246,16 @@ def test_equal_position_input_bindings_order_by_field_name(order: tuple[str, ...
         for name in order
     }
     command = lower_command({"baseCommand": "cmd", "arguments": ["a", "b", "c"], "inputs": inputs})
+    templates = [token for token in command.tokens if isinstance(token, NfTemplate)]
+    assert len(templates) == len(command.tokens), "string bindings never lower to flag tokens"
     references = [
         segment.name
-        for token in command.tokens
+        for token in templates
         for segment in token.segments
         if isinstance(segment, NfInputReference)
     ]
     literals: list[str] = []
-    for token in command.tokens[:4]:
+    for token in templates[:4]:
         segment = token.segments[0]
         assert isinstance(segment, NfLiteral)
         literals.append(segment.value)

--- a/tests/core/nextflow/test_reader.py
+++ b/tests/core/nextflow/test_reader.py
@@ -10,7 +10,11 @@ from typing import Any, cast
 import pytest
 
 from sophios.api.python.workflow import CompiledWorkflow, Step, Workflow
-from sophios.input_output_nf import render_nextflow, write_nextflow_artifacts
+from sophios.input_output_nf import (
+    render_nextflow,
+    render_nextflow_params,
+    write_nextflow_artifacts,
+)
 from sophios.nf_reader import (
     NextflowDocument,
     NextflowPort,
@@ -30,7 +34,7 @@ from sophios.nf_types import (
     NfWorkflowOutputConnection,
 )
 
-from .testkit import command, output_port, ref, runtime_workflow, template
+from .testkit import command, flag_workflow, output_port, ref, runtime_workflow, template
 
 
 @pytest.mark.fast
@@ -50,6 +54,37 @@ def test_generated_source_roundtrips_through_reader(tmp_path: Path) -> None:
     assert promote_nextflow_document(parsed) == expected
     with pytest.raises(TypeError, match="requires ExecutableNextflowWorkflow"):
         render_nextflow(cast(Any, parsed))
+
+
+@pytest.mark.fast
+def test_flag_artifacts_parse_and_promote(tmp_path: Path) -> None:
+    """Promotion is byte-identity bound, so a new token shape must round-trip."""
+    expected = flag_workflow()
+    write_nextflow_artifacts(expected, tmp_path)
+
+    parsed = parse_nf_file(tmp_path / "workflow.nf")
+
+    assert parsed.opaque_regions == ()
+    assert promote_nextflow_document(parsed) == expected
+
+
+@pytest.mark.fast
+def test_prior_schema_version_artifacts_still_promote(tmp_path: Path) -> None:
+    """A v2-era artifact pair keeps promoting; renderer output is the contract."""
+    workflow = runtime_workflow()
+    payload = workflow.to_dict()
+    payload["schema_version"] = 2
+    (tmp_path / "nextflow_workflow.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (tmp_path / "workflow.nf").write_text(render_nextflow(workflow), encoding="utf-8")
+    (tmp_path / "nextflow_params.json").write_text(
+        render_nextflow_params(workflow), encoding="utf-8"
+    )
+
+    parsed = parse_nf_file(tmp_path / "workflow.nf")
+
+    assert promote_nextflow_document(parsed) == workflow
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_renderer.py
+++ b/tests/core/nextflow/test_renderer.py
@@ -26,7 +26,7 @@ from sophios.nf_types import (
 from sophios.utils_nf import cwl_rosetree_to_nextflow
 from sophios.wic_types import RoseTree
 
-from .testkit import command, output_port, runtime_workflow
+from .testkit import command, flag_workflow, output_port, runtime_workflow
 
 
 @pytest.mark.serial
@@ -162,6 +162,18 @@ def test_renders_boolean_flag_as_a_conditional_argv_word() -> None:
     ))
 
     assert "${reverse ? __sophios_shell_quote_9f72e('-r') : ''}" in rendered
+
+
+@pytest.mark.serial
+def test_flag_workflow_artifacts_are_byte_stable(tmp_path: Path) -> None:
+    workflow = flag_workflow()
+    paths = write_nextflow_artifacts(workflow, tmp_path)
+    first = {path.name: path.read_bytes() for path in paths}
+
+    write_nextflow_artifacts(workflow, tmp_path)
+
+    assert {path.name: path.read_bytes() for path in paths} == first
+    assert render_nextflow(workflow) == render_nextflow(workflow)
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_renderer.py
+++ b/tests/core/nextflow/test_renderer.py
@@ -14,9 +14,13 @@ from sophios.input_output_nf import (
 )
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfCommand,
+    NfFlag,
+    NfLiteral,
     NfPort,
     NfProcess,
     NfResources,
+    NfTemplate,
     NfWorkflowInputConnection,
 )
 from sophios.utils_nf import cwl_rosetree_to_nextflow
@@ -137,6 +141,27 @@ def test_path_parameter_rendering_is_runtime_shape_independent() -> None:
         "Channel.fromPath(params.source instanceof Map ? params.source.path : "
         "params.source, checkIfExists: true, type: 'file', glob: false)"
     ) in rendered
+
+
+@pytest.mark.serial
+def test_renders_boolean_flag_as_a_conditional_argv_word() -> None:
+    process = NfProcess(
+        "SORT",
+        [NfPort("reverse", "val")],
+        [output_port("result", "sorted.txt")],
+        NfCommand(
+            (NfTemplate((NfLiteral("sort"),)), NfFlag("reverse", "-r")),
+            stdout=NfTemplate((NfLiteral("sorted.txt"),)),
+        ),
+    )
+    rendered = render_nextflow(ExecutableNextflowWorkflow(
+        "WF",
+        [process],
+        [NfWorkflowInputConnection("reverse", "SORT", "reverse")],
+        {"reverse": True},
+    ))
+
+    assert "${reverse ? __sophios_shell_quote_9f72e('-r') : ''}" in rendered
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_runtime.py
+++ b/tests/core/nextflow/test_runtime.py
@@ -406,6 +406,62 @@ def test_four_step_checked_in_adapter_workflow_executes_end_to_end(
 
 @pytest.mark.nextflow
 @pytest.mark.serial
+@pytest.mark.parametrize(
+    ("reverse", "expected"),
+    [(True, "beta\nalpha\n"), (False, "alpha\nbeta\n")],
+    ids=["reversed", "forward"],
+)
+def test_boolean_flag_changes_observable_command_behavior(
+    reverse: bool,
+    expected: str,
+    tmp_path: Path,
+) -> None:
+    """R2.1: one real compiled fixture, two flag values, two observable results."""
+    write_tool = (
+        CommandLineTool(
+            "write_lines",
+            Inputs(
+                first=Input(cwl.string, position=2),
+                second=Input(cwl.string, position=3),
+            ),
+            Outputs(result=Output(cwl.file, glob="lines.txt")),
+        )
+        .base_command("printf")
+        .argument("%s\\n%s\\n", position=1)
+        .stdout("lines.txt")
+    )
+    write = Step(write_tool, step_name="write_lines")
+    write.inputs.first = "alpha"
+    write.inputs.second = "beta"
+
+    sort_tool = (
+        CommandLineTool(
+            "sort_lines",
+            Inputs(
+                reverse=Input(cwl.boolean, position=1, flag="-r"),
+                source=Input(cwl.file, position=2),
+            ),
+            Outputs(result=Output(cwl.file, glob="sorted.txt")),
+        )
+        .base_command("sort")
+        .stdout("sorted.txt")
+    )
+    sort_step = Step(sort_tool, step_name="sort_lines")
+    sort_step.inputs.reverse = reverse
+    sort_step.inputs.source = write.outputs.result
+
+    workflow = Workflow([write, sort_step], "nextflow_boolean_flag")
+    workflow.outputs.sorted = sort_step.outputs.result
+
+    workflow.to_nextflow(tmp_path)
+    result = execute_nextflow(tmp_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    outputs = list((tmp_path / "work").rglob("sorted.txt"))
+    assert [path.read_text(encoding="utf-8") for path in outputs] == [expected]
+
+
+@pytest.mark.nextflow
+@pytest.mark.serial
 def test_mixed_adapter_and_builder_workflow_executes_end_to_end(tmp_path: Path) -> None:
     """One workflow mixing an imported adapter with tool_builder steps runs end to end.
 

--- a/tests/core/nextflow/testkit.py
+++ b/tests/core/nextflow/testkit.py
@@ -13,6 +13,7 @@ from sophios.input_output_nf import write_nextflow_artifacts
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
     NfCommand,
+    NfFlag,
     NfInputReference,
     NfLiteral,
     NfPort,
@@ -172,6 +173,33 @@ def runtime_workflow() -> ExecutableNextflowWorkflow:
             NfWorkflowOutputConnection("COPY", "copy", "result"),
         ],
         {"message": "hello from Sophios"},
+    )
+
+
+def flag_workflow() -> ExecutableNextflowWorkflow:
+    """A one-process pipeline whose command carries a conditional flag token."""
+    process = NfProcess(
+        "SORT",
+        [NfPort("reverse", "val"), NfPort("source", "path")],
+        [output_port("result", "sorted.txt")],
+        NfCommand(
+            (
+                template("sort"),
+                NfFlag("reverse", "-r"),
+                template(ref("source")),
+            ),
+            stdout=template("sorted.txt"),
+        ),
+    )
+    return ExecutableNextflowWorkflow(
+        "PIPELINE",
+        [process],
+        [
+            NfWorkflowInputConnection("reverse", "SORT", "reverse"),
+            NfWorkflowInputConnection("source", "SORT", "source"),
+            NfWorkflowOutputConnection("SORT", "result", "result"),
+        ],
+        {"reverse": True, "source": "lines.txt"},
     )
 
 


### PR DESCRIPTION
Stacked on #398 (`nfplan_1followon`).

## What this adds

Boolean `inputBinding` flags lower to real command-line flags instead of Phase 1's blanket rejection.

- A boolean input with an `inputBinding` prefix and no `valueFrom` lowers to a typed `NfFlag` token: `true` renders the shell-quoted prefix as one argv word, `false` renders nothing.
- No prefix means no contribution either way, matching CWL.
- The prefix goes through the generated shell-quote helper, so a hostile prefix can't inject shell syntax.

## Boundaries

- `NfFlag` is only valid in command token position — unrepresentable in globs or stream targets by type.
- Flags validate against `val` ports at construction, not render time.
- `valueFrom` on a boolean binding keeps its existing template treatment; absent optional booleans still reject.

## Schema

`flag` registers as the token kind introduced in `schema_version: 3`, the current version; hydration still accepts the strict-subset version 2. Evolution policy is in the design doc.

## Design authority

`design:` commit `09b5ef2` approves this per §10 of `design_docs/sophios_nextflow_backend.md`.

## Review fixes

- `valueFrom` on a boolean binding emitted an inverted flag (fell through the "is this a flag" check, so `false` still rendered the prefix). Now rejects in capability analysis instead.
- Nothing required the flag's source to actually be boolean — a `File` output pinned the flag on via Groovy truthiness. Capability analysis now resolves every flag source's type and requires boolean.
- `separate` without a `prefix` now matches cwltool exactly (including `separate: null`); a command whose argv is only conditional flags keeps its fallback program instead of rendering empty.
- A whitespace-only prefix now hits the named capability diagnostic instead of an unrelated `NfFlag` construction error.
- Design doc corrections: dropped a `valueFrom` rejection claim that never existed, fixed "non-optional" wording (here and in `docs/nextflow.md`), and made the schema-subset invariant actually enforced per-kind instead of just asserted.
- Closed coverage gaps the story declared but hadn't tested: flag ordering among other bindings, byte-stability with a flag present, and flag-bearing artifacts round-tripping through parse/promote.
- `NfFlag`/`NfCommandToken` weren't actually exported from `sophios.api.python.nextflow` despite an earlier version of this description claiming they were. Fixed and pinned with a test.
- Round 2: the flag-source guard's exemption was narrower than it needed to be and cost three mapping shapes their aggregating diagnostic — widened to any `Mapping`. None of the three `separate`/prefix/source-shape fixes above had a test that actually distinguished old from new behavior; added the three missing cases.
