### PR TITLE
feat(nextflow): lower $(inputs.x.basename) references

### DIFF
--- a/design_docs/sophios_nextflow_backend.md
+++ b/design_docs/sophios_nextflow_backend.md
@@ -174,6 +174,8 @@ Every output has a concrete capture mechanism. Phase-specific support may includ
 
 Supported glob expressions are parsed into typed literal and input-reference components. Raw CWL expression strings cannot enter the executable model. `loadContents`, `outputEval`, arbitrary expressions, and other capture behavior are rejected until their lowering is approved.
 
+**Basename references (approved Phase 2 lowering).** `$(inputs.<name>.basename)` lowers to a typed basename segment valid in every template position: command tokens, stream targets, and output globs. The referenced input must be a path port, because the lowering relies on Nextflow staging an input under its original file name, which makes the staged path's name property exactly the CWL `basename`. Basename segments against value ports are unrepresentable in the executable model.
+
 ### Topology
 
 The executable graph validates endpoint existence, direction, multiplicity, acyclicity where required, unique emits, normalized-name collisions, and workflow-boundary consistency before rendering.
@@ -261,6 +263,7 @@ Phase 2 does not authorize arbitrary Groovy parsing.
 Approved Phase 2 lowerings to date:
 
 - Boolean `inputBinding` flags (§6, Commands).
+- `$(inputs.<name>.basename)` references (§6, Outputs and globs).
 
 ### Phase 3 — Native inference, advanced execution, and service delivery
 

--- a/design_docs/sophios_nextflow_backend.md
+++ b/design_docs/sophios_nextflow_backend.md
@@ -170,11 +170,11 @@ Channel construction considers all consumers. Connection order never selects a q
 
 ### Outputs and globs
 
-Every output has a concrete capture mechanism. Phase-specific support may include path globs and declared stdout/stderr file capture. Primitive outputs are not represented as bare variable names.
+Every output has a concrete capture mechanism. Phase-specific support may include path globs and declared stdout/stderr file capture. Primitive outputs are not represented as bare variable names. A rendered glob remains a glob at run time: a name assembled from runtime data is still pattern-interpreted, so a staged name carrying a glob metacharacter does not match the file the process wrote. Rendering an assembled name literally is a distinct lowering, because it changes emitted bytes and the generated-subset reader with them.
 
 Supported glob expressions are parsed into typed literal and input-reference components. Raw CWL expression strings cannot enter the executable model. `loadContents`, `outputEval`, arbitrary expressions, and other capture behavior are rejected until their lowering is approved.
 
-**Basename references (approved Phase 2 lowering).** `$(inputs.<name>.basename)` lowers to a typed basename segment valid in every template position: command tokens, stream targets, and output globs. The referenced input must be a path port, because the lowering relies on Nextflow staging an input under its original file name, which makes the staged path's name property exactly the CWL `basename`. Basename segments against value ports are unrepresentable in the executable model.
+**Basename references (approved Phase 2 lowering).** `$(inputs.<name>.basename)` lowers to a typed basename segment valid in every template position: command tokens, stream targets, and output globs. The referenced input must be a path port, because the lowering relies on Nextflow staging an input under its original file name, which makes the staged path's name property exactly the CWL `basename`. Basename segments against value ports are unrepresentable in the executable model, and the same requirement is reported by path during capability analysis, so a source document naming a value input reports every offending position at once rather than failing later on a normalized identifier. In output-glob position the reference must derive a new name: a declaration matching only a staged input captures nothing.
 
 ### Topology
 

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -84,6 +84,23 @@ exactly one argument and `false` contributes nothing. A boolean binding
 without a prefix contributes nothing for either value, matching CWL. Absent
 optional booleans still reject until option lowering is approved.
 
+## Basename references
+
+`$(inputs.<name>.basename)` is supported in command arguments, stream targets,
+and output globs, so a tool can name its outputs after a staged input:
+
+```yaml
+outputs:
+  result:
+    type: File
+    outputBinding:
+      glob: $(inputs.source.basename).copy
+```
+
+The reference must target a `File` or `Directory` input. Nextflow stages an
+input under its original file name, so the staged name is exactly the CWL
+`basename`.
+
 ## Current limits
 
 - Workflows must be flat and use `CommandLineTool`-equivalent processes.

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -101,6 +101,17 @@ The reference must target a `File` or `Directory` input. Nextflow stages an
 input under its original file name, so the staged name is exactly the CWL
 `basename`.
 
+The `.copy` suffix above is load-bearing: a basename glob must derive a **new**
+name. A Nextflow output declaration does not capture staged inputs, so a glob
+naming only the input itself compiles cleanly and then fails at run time with
+`Missing output file(s)`.
+
+Two further limits apply to a rendered glob. It stays a Nextflow glob pattern,
+so a staged name containing `*`, `?`, `[`, `{` or `}` is interpreted as a
+pattern rather than matched literally, and the process fails to find the file
+it wrote. Rendering such a name literally is a separate change, because it
+alters emitted bytes and the generated-subset reader with them.
+
 ## Current limits
 
 - Workflows must be flat and use `CommandLineTool`-equivalent processes.

--- a/src/sophios/api/python/nextflow.py
+++ b/src/sophios/api/python/nextflow.py
@@ -8,6 +8,7 @@ from sophios.input_output_nf import (
 )
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfBasenameReference,
     NfCommand,
     NfCommandToken,
     NfConnection,
@@ -37,6 +38,7 @@ from sophios.nf_reader import (
 
 __all__ = [
     "ExecutableNextflowWorkflow",
+    "NfBasenameReference",
     "NfCommand",
     "NfCommandToken",
     "NfConnection",

--- a/src/sophios/input_output_nf.py
+++ b/src/sophios/input_output_nf.py
@@ -9,6 +9,7 @@ from typing import Any
 from .nf_types import (
     ExecutableNextflowWorkflow,
     NF_SHELL_QUOTE_HELPER,
+    NfBasenameReference,
     NfConnection,
     NfFlag,
     NfInputReference,
@@ -58,13 +59,18 @@ def _groovy_gstring_fragment(value: str) -> str:
     return value.translate(_GSTRING_FRAGMENT_TABLE)
 
 
+def _segment_expression(segment: Any) -> str:
+    match segment:
+        case NfInputReference():
+            return f"{segment.name}.toString()"
+        case NfBasenameReference():
+            return f"{segment.name}.name.toString()"
+        case _:
+            return _groovy_literal(segment.value)
+
+
 def _template_expression(template: Any) -> str:
-    return " + ".join(
-        f"{segment.name}.toString()"
-        if isinstance(segment, NfInputReference)
-        else _groovy_literal(segment.value)
-        for segment in template.segments
-    )
+    return " + ".join(_segment_expression(segment) for segment in template.segments)
 
 
 def _shell_quote(value: str) -> str:
@@ -90,10 +96,13 @@ def _render_glob(template: Any) -> str:
         return _groovy_literal("".join(segment.value for segment in template.segments))
     rendered: list[str] = []
     for segment in template.segments:
-        if isinstance(segment, NfInputReference):
-            rendered.append(f"${{{segment.name}}}")
-        else:
-            rendered.append(_groovy_gstring_fragment(segment.value))
+        match segment:
+            case NfInputReference():
+                rendered.append(f"${{{segment.name}}}")
+            case NfBasenameReference():
+                rendered.append(f"${{{segment.name}.name}}")
+            case _:
+                rendered.append(_groovy_gstring_fragment(segment.value))
     return f'"{"".join(rendered)}"'
 
 

--- a/src/sophios/nf_types.py
+++ b/src/sophios/nf_types.py
@@ -152,7 +152,30 @@ class NfInputReference:
         return {"kind": "input", "name": self.name}
 
 
-NfTemplateSegment = NfLiteral | NfInputReference
+@dataclass(frozen=True, slots=True)
+class NfBasenameReference:
+    """Reference to the staged file name of one path input.
+
+    Nextflow stages an input under its original file name, so the staged
+    path's name is exactly the CWL ``basename``.
+    """
+
+    name: str
+
+    def __post_init__(self) -> None:
+        _validate_ir_identifier(self.name, field_name="template basename reference")
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-compatible representation.
+
+        Returns:
+            dict[str, str]: The segment as ``{"kind": "basename", "name": ...}``.
+        """
+        return {"kind": "basename", "name": self.name}
+
+
+NfTemplateSegment = NfLiteral | NfInputReference | NfBasenameReference
+NfReferenceSegment = NfInputReference | NfBasenameReference
 
 
 def _segment_from_dict(value: Mapping[str, Any]) -> NfTemplateSegment:
@@ -164,6 +187,9 @@ def _segment_from_dict(value: Mapping[str, Any]) -> NfTemplateSegment:
         case "input":
             _check_fields(item, type_name="NfInputReference", required={"kind", "name"})
             return NfInputReference(item["name"])
+        case "basename":
+            _check_fields(item, type_name="NfBasenameReference", required={"kind", "name"})
+            return NfBasenameReference(item["name"])
         case kind:
             raise ValueError(f"unsupported template segment kind {kind!r}")
 
@@ -177,7 +203,7 @@ class NfTemplate:
     def __post_init__(self) -> None:
         canonical: list[NfTemplateSegment] = []
         for segment in self.segments:
-            if not isinstance(segment, (NfLiteral, NfInputReference)):
+            if not isinstance(segment, (NfLiteral, NfInputReference, NfBasenameReference)):
                 raise TypeError("template segments must be typed literal or input references")
             if isinstance(segment, NfLiteral) and canonical and isinstance(canonical[-1], NfLiteral):
                 canonical[-1] = NfLiteral(canonical[-1].value + segment.value)
@@ -487,20 +513,26 @@ class NfProcess:
             *(template for template in (self.command.stdin, self.command.stdout, self.command.stderr) if template),
             *(port.glob for port in outputs if port.glob),
         ]
-        references = flag_names | {
-            segment.name
-            for template in templates
-            for segment in template.segments
-            if isinstance(segment, NfInputReference)
+        segments = [segment for template in templates for segment in template.segments]
+        basename_names = {
+            segment.name for segment in segments if isinstance(segment, NfBasenameReference)
+        }
+        references = flag_names | basename_names | {
+            segment.name for segment in segments if isinstance(segment, NfInputReference)
         }
         if unknown := references - input_names:
             raise ValueError(
                 f"process {self.name!r} templates reference unknown inputs: {', '.join(sorted(unknown))}"
             )
-        value_names = {port.name for port in inputs if port.qualifier == "val"}
-        if invalid := flag_names - value_names:
+        qualifiers = {port.name: port.qualifier for port in inputs}
+        if invalid := {name for name in flag_names if qualifiers[name] != "val"}:
             raise ValueError(
                 f"process {self.name!r} flag tokens must reference val inputs: "
+                f"{', '.join(sorted(invalid))}"
+            )
+        if invalid := {name for name in basename_names if qualifiers[name] != "path"}:
+            raise ValueError(
+                f"process {self.name!r} basename references must target path inputs: "
                 f"{', '.join(sorted(invalid))}"
             )
         match self.container:
@@ -743,13 +775,15 @@ def _connection_from_dict(value: Mapping[str, Any]) -> NfConnection:
 class ExecutableNextflowWorkflow:
     """Closed, immutable, versioned executable representation of a DSL2 workflow."""
 
-    SCHEMA_VERSION: ClassVar[int] = 3
+    SCHEMA_VERSION: ClassVar[int] = 4
     # Earlier versions whose value space is a strict subset of the current
     # model hydrate unchanged; serialization always writes SCHEMA_VERSION.
-    SUPPORTED_SCHEMA_VERSIONS: ClassVar[frozenset[int]] = frozenset({2, 3})
+    SUPPORTED_SCHEMA_VERSIONS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
     # Each additive token or segment kind declares the version that
     # introduced it, so the subset property is enforced rather than assumed.
-    KIND_SCHEMA_VERSIONS: ClassVar[Mapping[str, int]] = MappingProxyType({"flag": 3})
+    KIND_SCHEMA_VERSIONS: ClassVar[Mapping[str, int]] = MappingProxyType(
+        {"flag": 3, "basename": 4}
+    )
     REPRESENTATION_KIND: ClassVar[str] = "executable"
 
     name: str

--- a/src/sophios/nf_types.py
+++ b/src/sophios/nf_types.py
@@ -6,7 +6,7 @@ from graphlib import CycleError, TopologicalSorter
 import json
 import math
 from types import MappingProxyType
-from typing import Any, ClassVar, Generic, Self, TypeVar
+from typing import Any, ClassVar, Generic, Self, TypeVar, get_args
 
 from .nf_symbols import validate_nextflow_identifier
 
@@ -175,7 +175,6 @@ class NfBasenameReference:
 
 
 NfTemplateSegment = NfLiteral | NfInputReference | NfBasenameReference
-NfReferenceSegment = NfInputReference | NfBasenameReference
 
 
 def _segment_from_dict(value: Mapping[str, Any]) -> NfTemplateSegment:
@@ -203,8 +202,9 @@ class NfTemplate:
     def __post_init__(self) -> None:
         canonical: list[NfTemplateSegment] = []
         for segment in self.segments:
-            if not isinstance(segment, (NfLiteral, NfInputReference, NfBasenameReference)):
-                raise TypeError("template segments must be typed literal or input references")
+            if not isinstance(segment, get_args(NfTemplateSegment)):
+                accepted = ", ".join(kind.__name__ for kind in get_args(NfTemplateSegment))
+                raise TypeError(f"template segments must be one of: {accepted}")
             if isinstance(segment, NfLiteral) and canonical and isinstance(canonical[-1], NfLiteral):
                 canonical[-1] = NfLiteral(canonical[-1].value + segment.value)
             elif not isinstance(segment, NfLiteral) or segment.value:

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -11,6 +11,7 @@ from .nf_symbols import normalize_nextflow_identifier
 from .nf_types import (
     ExecutableNextflowWorkflow,
     NF_INTERNAL_IDENTIFIERS,
+    NfBasenameReference,
     NfCommand,
     NfCommandToken,
     NfConnection,
@@ -22,6 +23,7 @@ from .nf_types import (
     NfProcessConnection,
     NfResources,
     NfTemplate,
+    NfTemplateSegment,
     NfWorkflowInputConnection,
     NfWorkflowOutputConnection,
 )
@@ -169,9 +171,8 @@ def _ports(raw_ports: Any, *, outputs: bool) -> list[NfPort]:
 
 
 _INPUT_EXPRESSION = re.compile(
-    r"\$\(\s*inputs\.([A-Za-z_][A-Za-z0-9_]*)(?:\.path)?\s*\)"
+    r"\$\(\s*inputs\.([A-Za-z_][A-Za-z0-9_]*)(?:\.(path|basename))?\s*\)"
 )
-_BASENAME_EXPRESSION = re.compile(r"\$\(\s*inputs\.[A-Za-z_][A-Za-z0-9_]*\.basename\s*\)")
 
 
 def _template(value: Any, *, context: str) -> NfTemplate:
@@ -184,24 +185,23 @@ def _template(value: Any, *, context: str) -> NfTemplate:
             pass
         case _:
             raise ValueError(f"unsupported CWL command value {value!r}")
-    if _BASENAME_EXPRESSION.search(text):
-        raise ValueError(
-            f"{context} uses $(inputs.<name>.basename); basename lowering is deferred to Phase 2"
-        )
-    segments: list[NfLiteral | NfInputReference] = []
+    segments: list[NfTemplateSegment] = []
     offset = 0
     for match in _INPUT_EXPRESSION.finditer(text):
         if match.start() > offset:
             segments.append(NfLiteral(text[offset:match.start()]))
-        segments.append(NfInputReference(_identifier(match.group(1), context="input reference")))
+        name = _identifier(match.group(1), context="input reference")
+        segments.append(
+            NfBasenameReference(name) if match.group(2) == "basename" else NfInputReference(name)
+        )
         offset = match.end()
     if offset < len(text):
         segments.append(NfLiteral(text[offset:]))
     residual = _INPUT_EXPRESSION.sub("", text)
     if "$" in residual:
         raise ValueError(
-            f"{context} contains an unsupported CWL expression; Phase 1 supports only "
-            "$(inputs.<name>), optionally followed by .path"
+            f"{context} contains an unsupported CWL expression; the supported form is "
+            "$(inputs.<name>), optionally followed by .path or .basename"
         )
     return NfTemplate(tuple(segments or [NfLiteral(text)]))
 

--- a/src/sophios/utils_nf.py
+++ b/src/sophios/utils_nf.py
@@ -624,6 +624,129 @@ def _requirement_names(section: Any) -> list[tuple[str, str]]:
             return []
 
 
+def _basename_template_positions(
+    tool: Mapping[str, Any],
+    *,
+    path: str,
+) -> list[tuple[Any, str]]:
+    """Pair every templated tool value with the CWL path it was written at.
+
+    A basename reference is legal in any template position, so the
+    source-level requirement has to look everywhere one can appear rather
+    than only in output globs.
+    """
+    positions: list[tuple[Any, str]] = []
+    match tool.get("baseCommand"):
+        case str() as command:
+            positions.append((command, f"{path}.run.baseCommand"))
+        case list() as commands:
+            positions.extend(
+                (token, f"{path}.run.baseCommand[{index}]")
+                for index, token in enumerate(commands)
+            )
+        case _:
+            pass
+    match tool.get("arguments"):
+        case list() as arguments:
+            for index, argument in enumerate(arguments):
+                argument_path = f"{path}.run.arguments[{index}]"
+                match argument:
+                    case Mapping() as mapping if mapping.get("valueFrom") is not None:
+                        positions.append((mapping["valueFrom"], f"{argument_path}.valueFrom"))
+                    case Mapping():
+                        pass
+                    case _:
+                        positions.append((argument, argument_path))
+        case _:
+            pass
+    match tool.get("inputs"):
+        case Mapping() as inputs:
+            for raw_name, definition in inputs.items():
+                if not isinstance(definition, Mapping):
+                    continue
+                binding = definition.get("inputBinding")
+                if not isinstance(binding, Mapping):
+                    continue
+                binding_path = f"{path}.run.inputs.{raw_name}.inputBinding"
+                for field_name in ("prefix", "valueFrom"):
+                    if binding.get(field_name) is not None:
+                        positions.append((binding[field_name], f"{binding_path}.{field_name}"))
+        case _:
+            pass
+    for stream in ("stdin", "stdout", "stderr"):
+        if tool.get(stream) is not None:
+            positions.append((tool[stream], f"{path}.run.{stream}"))
+    match tool.get("outputs"):
+        case Mapping() as outputs:
+            for raw_name, definition in outputs.items():
+                if not isinstance(definition, Mapping):
+                    continue
+                binding = definition.get("outputBinding")
+                if not isinstance(binding, Mapping):
+                    continue
+                if binding.get("glob") is not None:
+                    positions.append(
+                        (
+                            binding["glob"],
+                            f"{path}.run.outputs.{raw_name}.outputBinding.glob",
+                        )
+                    )
+        case _:
+            pass
+    return positions
+
+
+def _basename_source_findings(tool: Mapping[str, Any], *, path: str) -> list[str]:
+    """Require a File or Directory source for every basename reference.
+
+    A basename reference renders the staged path's ``name`` property, which
+    equals the CWL ``basename`` only because Nextflow stages a path input
+    under its original file name; a val-qualified input is never staged, so
+    the reference has nothing to read. ``NfProcess`` rejects the same shape
+    as a model invariant, but that raise names normalized identifiers,
+    carries no source location, and stops at the first offender, so the
+    source-level requirement is reported here by CWL path and aggregates
+    with every other finding.
+    """
+    raw_inputs = tool.get("inputs", {})
+    if not isinstance(raw_inputs, Mapping):
+        return []
+    declared: dict[str, Any] = {}
+    for raw_name, definition in raw_inputs.items():
+        if not isinstance(definition, Mapping):
+            continue
+        try:
+            declared[_identifier(raw_name, context="tool input")] = definition.get("type")
+        except ValueError:
+            continue
+    findings: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for value, position in _basename_template_positions(tool, path=path):
+        try:
+            template = _template(value, context="basename source")
+        except ValueError:
+            # An unsupported expression form is reported by the pass that
+            # owns it; this one only judges the references it can read.
+            continue
+        for segment in template.segments:
+            if not isinstance(segment, NfBasenameReference):
+                continue
+            if segment.name not in declared or (position, segment.name) in seen:
+                continue
+            try:
+                qualifier = cwl_type_to_nf_qualifier(declared[segment.name])
+            except ValueError:
+                continue
+            if qualifier == "path":
+                continue
+            seen.add((position, segment.name))
+            findings.append(
+                f"{position}: $(inputs.{segment.name}.basename) requires a File or "
+                f"Directory input; {segment.name} lowers to a {qualifier} channel"
+            )
+    return findings
+
+
 def _tool_capability_findings(
     step: Mapping[str, Any],
     child: RoseTree,
@@ -670,6 +793,7 @@ def _tool_capability_findings(
             path=f"{path}.run",
         )
     )
+    findings.extend(_basename_source_findings(tool, path=path))
 
     for section_name in ("requirements", "hints"):
         section = tool.get(section_name)

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -512,27 +512,27 @@ def test_rejects_absent_optional_workflow_input_feeding_required_input() -> None
 
 
 @pytest.mark.fast
-def test_rejects_basename_input_expressions() -> None:
+def test_rejects_basename_against_a_value_input() -> None:
     basename = tool(
         "BASENAME",
-        inputs={"source": {"type": "File"}},
+        inputs={"label": {"type": "string"}},
         outputs={
             "result": {
                 "type": "File",
-                "outputBinding": {"glob": "$(inputs.source.basename).txt"},
+                "outputBinding": {"glob": "$(inputs.label.basename).txt"},
             }
         },
     )
     rose = synthetic_rose(
         workflow_doc(
-            [step("BASENAME", **{"in": {"source": "source"}, "out": ["result"]})],
-            inputs={"source": {"type": "File"}},
+            [step("BASENAME", **{"in": {"label": "label"}, "out": ["result"]})],
+            inputs={"label": {"type": "string"}},
             outputs={"result": {"type": "File", "outputSource": "BASENAME/result"}},
         ),
         [basename],
-        workflow_inputs={"source": {"class": "File", "path": "input.txt"}},
+        workflow_inputs={"label": "input"},
     )
-    with pytest.raises(ValueError, match="basename"):
+    with pytest.raises(ValueError, match="basename.*path"):
         cwl_rosetree_to_nextflow(rose)
 
 

--- a/tests/core/nextflow/test_capabilities.py
+++ b/tests/core/nextflow/test_capabilities.py
@@ -16,6 +16,21 @@ from sophios.wic_types import RoseTree
 
 from .testkit import node_data, step, synthetic_rose, tool, workflow_doc
 
+_FINDINGS_HEADER = "Nextflow Phase 1 capability analysis failed:\n"
+
+
+def _findings(error: BaseException) -> list[str]:
+    """Split an aggregated capability diagnostic into its individual findings.
+
+    Returning the list lets a test pin the closed shape -- how many findings
+    fired, their exact text, and the source path each is tagged with --
+    rather than only that some substring appeared somewhere.
+    """
+    diagnostic = str(error)
+    assert diagnostic.startswith(_FINDINGS_HEADER), diagnostic
+    body = diagnostic[len(_FINDINGS_HEADER):]
+    return [line.removeprefix("- ") for line in body.split("\n")]
+
 
 @pytest.mark.fast
 def test_real_unsupported_rosetree_aggregates_capability_errors(
@@ -532,8 +547,49 @@ def test_rejects_basename_against_a_value_input() -> None:
         [basename],
         workflow_inputs={"label": "input"},
     )
-    with pytest.raises(ValueError, match="basename.*path"):
+    with pytest.raises(ValueError) as excinfo:
         cwl_rosetree_to_nextflow(rose)
+    assert _findings(excinfo.value) == [
+        "steps[0].run.outputs.result.outputBinding.glob: $(inputs.label.basename) "
+        "requires a File or Directory input; label lowers to a val channel"
+    ]
+
+
+@pytest.mark.fast
+def test_reports_every_basename_against_a_value_input_by_path() -> None:
+    basename = tool(
+        "BASENAME",
+        inputs={"label": {"type": "string"}, "tag": {"type": "string"}},
+        outputs={
+            "result": {
+                "type": "File",
+                "outputBinding": {"glob": "$(inputs.label.basename).txt"},
+            }
+        },
+        stdout="$(inputs.tag.basename).log",
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [
+                step(
+                    "BASENAME",
+                    **{"in": {"label": "label", "tag": "tag"}, "out": ["result"]},
+                )
+            ],
+            inputs={"label": {"type": "string"}, "tag": {"type": "string"}},
+            outputs={"result": {"type": "File", "outputSource": "BASENAME/result"}},
+        ),
+        [basename],
+        workflow_inputs={"label": "input", "tag": "name"},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        cwl_rosetree_to_nextflow(rose)
+    assert _findings(excinfo.value) == [
+        "steps[0].run.stdout: $(inputs.tag.basename) requires a File or Directory "
+        "input; tag lowers to a val channel",
+        "steps[0].run.outputs.result.outputBinding.glob: $(inputs.label.basename) "
+        "requires a File or Directory input; label lowers to a val channel",
+    ]
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -226,6 +226,26 @@ def test_basename_segment_must_reference_a_path_input() -> None:
 
 
 @pytest.mark.fast
+def test_basename_port_rule_covers_stream_and_glob_positions() -> None:
+    """The design claims validity in every template position, so check them all."""
+    derived = NfTemplate((NfBasenameReference("source"),))
+    with pytest.raises(ValueError, match="basename.*path"):
+        NfProcess(
+            "COPY",
+            [NfPort("source", "val")],
+            [],
+            NfCommand((NfTemplate((NfLiteral("cp"),)),), stdout=derived),
+        )
+    with pytest.raises(ValueError, match="basename.*path"):
+        NfProcess(
+            "COPY",
+            [NfPort("source", "val")],
+            [NfPort("result", "path", "result", derived)],
+            NfCommand((NfTemplate((NfLiteral("cp"),)),)),
+        )
+
+
+@pytest.mark.fast
 def test_hydration_accepts_earlier_subset_schema_versions() -> None:
     payload = ExecutableNextflowWorkflow(
         "wf", [NfProcess("P", [], [], command("true"))], [], {}

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -10,6 +10,7 @@ import pytest
 from sophios.nf_symbols import is_nextflow_identifier, normalize_nextflow_identifier
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfBasenameReference,
     NfCommand,
     NfCommandToken,
     NfFlag,
@@ -69,14 +70,14 @@ def test_executable_schema_declares_version_and_kind() -> None:
     workflow = ExecutableNextflowWorkflow("wf", [], [], {})
     payload = workflow.to_dict()
 
-    assert payload["schema_version"] == 3
+    assert payload["schema_version"] == 4
     assert payload["representation_kind"] == "executable"
 
     payload["schema_version"] = 1
     with pytest.raises(ValueError, match="schema version"):
         ExecutableNextflowWorkflow.from_dict(payload)
 
-    payload["schema_version"] = 3
+    payload["schema_version"] = 4
     payload["representation_kind"] = "structural"
     with pytest.raises(ValueError, match="representation kind"):
         ExecutableNextflowWorkflow.from_dict(payload)
@@ -201,16 +202,41 @@ def test_flags_are_unrepresentable_outside_command_position() -> None:
 
 
 @pytest.mark.fast
+def test_basename_segment_survives_hydration() -> None:
+    process = NfProcess(
+        "COPY",
+        [NfPort("source", "path")],
+        [NfPort("result", "path", "result", NfTemplate((NfBasenameReference("source"),)))],
+        NfCommand((NfTemplate((NfLiteral("cp"),)), NfTemplate((NfBasenameReference("source"),)))),
+    )
+    assert NfProcess.from_dict(process.to_dict()) == process
+    assert NfBasenameReference("source").to_dict() == {
+        "kind": "basename",
+        "name": "source",
+    }
+
+
+@pytest.mark.fast
+def test_basename_segment_must_reference_a_path_input() -> None:
+    command = NfCommand((NfTemplate((NfLiteral("cp"),)), NfTemplate((NfBasenameReference("source"),))))
+    with pytest.raises(ValueError, match="unknown inputs"):
+        NfProcess("COPY", [], [], command)
+    with pytest.raises(ValueError, match="basename.*path"):
+        NfProcess("COPY", [NfPort("source", "val")], [], command)
+
+
+@pytest.mark.fast
 def test_hydration_accepts_earlier_subset_schema_versions() -> None:
     payload = ExecutableNextflowWorkflow(
         "wf", [NfProcess("P", [], [], command("true"))], [], {}
     ).to_dict()
-    assert payload["schema_version"] == 3
+    assert payload["schema_version"] == 4
 
-    payload["schema_version"] = 2
-    assert ExecutableNextflowWorkflow.from_dict(payload).to_dict()["schema_version"] == 3
+    for earlier in (2, 3):
+        payload["schema_version"] = earlier
+        assert ExecutableNextflowWorkflow.from_dict(payload).to_dict()["schema_version"] == 4
 
-    for unsupported in (1, 4):
+    for unsupported in (1, 5):
         payload["schema_version"] = unsupported
         with pytest.raises(ValueError, match="schema version"):
             ExecutableNextflowWorkflow.from_dict(payload)

--- a/tests/core/nextflow/test_executable_ir.py
+++ b/tests/core/nextflow/test_executable_ir.py
@@ -197,8 +197,14 @@ def test_flag_must_reference_a_declared_value_input() -> None:
 
 @pytest.mark.fast
 def test_flags_are_unrepresentable_outside_command_position() -> None:
-    with pytest.raises(TypeError, match="typed literal or input references"):
+    with pytest.raises(TypeError) as excinfo:
         NfTemplate((cast(Any, NfFlag("reverse", "-r")),))
+    # The message is built from NfTemplateSegment, so every accepted kind is
+    # named without a second hand-maintained list beside the isinstance check.
+    message = str(excinfo.value)
+    assert message == (
+        "template segments must be one of: NfLiteral, NfInputReference, NfBasenameReference"
+    )
 
 
 @pytest.mark.fast
@@ -223,6 +229,18 @@ def test_basename_segment_must_reference_a_path_input() -> None:
         NfProcess("COPY", [], [], command)
     with pytest.raises(ValueError, match="basename.*path"):
         NfProcess("COPY", [NfPort("source", "val")], [], command)
+
+
+@pytest.mark.fast
+def test_basename_segment_accepts_both_path_kinds() -> None:
+    # The design claims File and Directory inputs alike; a directory port is
+    # staged under its own name too, so both path kinds carry a basename.
+    command = NfCommand((NfTemplate((NfLiteral("cp"),)), NfTemplate((NfBasenameReference("source"),))))
+    for path_kind in ("file", "directory"):
+        process = NfProcess(
+            "COPY", [NfPort("source", "path", path_kind=path_kind)], [], command
+        )
+        assert process.inputs[0].path_kind == path_kind
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_lowering.py
+++ b/tests/core/nextflow/test_lowering.py
@@ -10,6 +10,7 @@ import pytest
 from sophios import inference
 from sophios.input_output_nf import render_nextflow
 from sophios.nf_types import (
+    NfBasenameReference,
     NfFlag,
     NfInputReference,
     NfLiteral,
@@ -151,6 +152,40 @@ def test_flag_tokens_take_their_cwl_position_among_other_bindings() -> None:
     assert tokens[1] == NfTemplate((NfLiteral("--stable"),))
     assert tokens[2] == NfFlag("reverse", "-r")
     assert tokens[3] == NfTemplate((NfInputReference("source"),))
+
+
+@pytest.mark.fast
+def test_basename_lowers_to_a_typed_segment_in_every_template_position() -> None:
+    copy_tool = tool(
+        "COPY",
+        inputs={"source": {"type": "File", "inputBinding": {"position": 1}}},
+        outputs={
+            "result": {
+                "type": "File",
+                "outputBinding": {"glob": "$(inputs.source.basename).copy"},
+            }
+        },
+        arguments=[{"position": 2, "valueFrom": "$(inputs.source.basename).copy"}],
+        stdout="$(inputs.source.basename).log",
+    )
+    rose = synthetic_rose(
+        workflow_doc(
+            [step("COPY", **{"in": {"source": "source"}, "out": ["result"]})],
+            inputs={"source": {"type": "File"}},
+            outputs={"result": {"type": "File", "outputSource": "COPY/result"}},
+        ),
+        [copy_tool],
+        workflow_inputs={"source": {"class": "File", "path": "lines.txt"}},
+    )
+
+    process = cwl_rosetree_to_nextflow(rose).processes[0]
+
+    expected = (NfBasenameReference("source"), NfLiteral(".copy"))
+    assert process.outputs[0].glob == NfTemplate(expected)
+    assert process.command.tokens[-1] == NfTemplate(expected)
+    assert process.command.stdout == NfTemplate(
+        (NfBasenameReference("source"), NfLiteral(".log"))
+    )
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_reader.py
+++ b/tests/core/nextflow/test_reader.py
@@ -27,9 +27,14 @@ from sophios.nf_reader import (
 )
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfBasenameReference,
+    NfCommand,
+    NfInputReference,
+    NfLiteral,
     NfPort,
     NfProcess,
     NfResources,
+    NfTemplate,
     NfWorkflowInputConnection,
     NfWorkflowOutputConnection,
 )
@@ -60,6 +65,35 @@ def test_generated_source_roundtrips_through_reader(tmp_path: Path) -> None:
 def test_flag_artifacts_parse_and_promote(tmp_path: Path) -> None:
     """Promotion is byte-identity bound, so a new token shape must round-trip."""
     expected = flag_workflow()
+    write_nextflow_artifacts(expected, tmp_path)
+
+    parsed = parse_nf_file(tmp_path / "workflow.nf")
+
+    assert parsed.opaque_regions == ()
+    assert promote_nextflow_document(parsed) == expected
+
+
+@pytest.mark.fast
+def test_basename_artifacts_parse_and_promote(tmp_path: Path) -> None:
+    """A basename glob renders as a GString, so the reader must accept it back."""
+    derived = NfTemplate((NfBasenameReference("source"), NfLiteral(".copy")))
+    expected = ExecutableNextflowWorkflow(
+        "PIPELINE",
+        [NfProcess(
+            "COPY",
+            [NfPort("source", "path")],
+            [NfPort("result", "path", "result", derived)],
+            NfCommand(
+                (NfTemplate((NfLiteral("cp"),)), NfTemplate((NfInputReference("source"),)), derived),
+                stdout=NfTemplate((NfBasenameReference("source"), NfLiteral(".log"))),
+            ),
+        )],
+        [
+            NfWorkflowInputConnection("source", "COPY", "source"),
+            NfWorkflowOutputConnection("COPY", "result", "copied"),
+        ],
+        {"source": "lines.txt"},
+    )
     write_nextflow_artifacts(expected, tmp_path)
 
     parsed = parse_nf_file(tmp_path / "workflow.nf")

--- a/tests/core/nextflow/test_renderer.py
+++ b/tests/core/nextflow/test_renderer.py
@@ -14,6 +14,7 @@ from sophios.input_output_nf import (
 )
 from sophios.nf_types import (
     ExecutableNextflowWorkflow,
+    NfBasenameReference,
     NfCommand,
     NfFlag,
     NfLiteral,
@@ -174,6 +175,26 @@ def test_flag_workflow_artifacts_are_byte_stable(tmp_path: Path) -> None:
 
     assert {path.name: path.read_bytes() for path in paths} == first
     assert render_nextflow(workflow) == render_nextflow(workflow)
+
+
+@pytest.mark.serial
+def test_renders_basename_segments_in_commands_and_globs() -> None:
+    basename = NfTemplate((NfBasenameReference("source"), NfLiteral(".copy")))
+    process = NfProcess(
+        "COPY",
+        [NfPort("source", "path")],
+        [NfPort("result", "path", "result", basename)],
+        NfCommand((NfTemplate((NfLiteral("cp"),)), basename)),
+    )
+    rendered = render_nextflow(ExecutableNextflowWorkflow(
+        "WF",
+        [process],
+        [NfWorkflowInputConnection("source", "COPY", "source")],
+        {"source": "lines.txt"},
+    ))
+
+    assert "source.name.toString() + '.copy'" in rendered
+    assert 'path "${source.name}.copy", emit: result' in rendered
 
 
 @pytest.mark.fast

--- a/tests/core/nextflow/test_runtime.py
+++ b/tests/core/nextflow/test_runtime.py
@@ -462,6 +462,44 @@ def test_boolean_flag_changes_observable_command_behavior(
 
 @pytest.mark.nextflow
 @pytest.mark.serial
+def test_basename_derived_output_name_executes(tmp_path: Path) -> None:
+    """R2.2: an output file name derived from a staged input's basename."""
+    write_tool = (
+        CommandLineTool(
+            "write_source",
+            Inputs(message=Input(cwl.string, position=1)),
+            Outputs(result=Output(cwl.file, glob="lines.txt")),
+        )
+        .base_command("echo")
+        .stdout("lines.txt")
+    )
+    write = Step(write_tool, step_name="write_source")
+    write.inputs.message = "basename derived"
+
+    copy_tool = (
+        CommandLineTool(
+            "copy_named_after_source",
+            Inputs(source=Input(cwl.file, position=1)),
+            Outputs(result=Output(cwl.file, glob="$(inputs.source.basename).copy")),
+        )
+        .base_command("cp")
+        .argument("$(inputs.source.basename).copy", position=2)
+    )
+    copy_step = Step(copy_tool, step_name="copy_named_after_source")
+    copy_step.inputs.source = write.outputs.result
+
+    workflow = Workflow([write, copy_step], "nextflow_basename")
+    workflow.outputs.copied = copy_step.outputs.result
+
+    workflow.to_nextflow(tmp_path)
+    result = execute_nextflow(tmp_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    copies = list((tmp_path / "work").rglob("lines.txt.copy"))
+    assert [path.read_text(encoding="utf-8") for path in copies] == ["basename derived\n"]
+
+
+@pytest.mark.nextflow
+@pytest.mark.serial
 def test_mixed_adapter_and_builder_workflow_executes_end_to_end(tmp_path: Path) -> None:
     """One workflow mixing an imported adapter with tool_builder steps runs end to end.
 


### PR DESCRIPTION
Stacked on #400 (`nf201_boolean_flags`). Review after that branch; its commits appear here until it merges.

## What this adds

`$(inputs.<name>.basename)` is lowered instead of rejected, so a tool can name its outputs after a staged input.

- The expression becomes an `NfBasenameReference` segment, valid in command tokens, stream targets, and output globs.
- Rendering uses the staged path's name property: `name.name.toString()` inside quoted command expressions, `${name.name}` inside glob GStrings.
- Phase 1 conflated `$(inputs.x.path)` and `$(inputs.x.basename)` into one reference before rejecting the latter outright; the two are now distinct typed segments.

## Boundaries

- A basename segment requires a `path` port and is rejected against `val` ports at model construction — the lowering can never claim a basename for a value channel.
- Everything else in the expression grammar is unchanged: any residual `$` still fails as an unsupported CWL expression.

## Schema

Adds `schema_version: 4` for the new segment kind, with hydration accepting 2 and 3 under the same evolution policy as #400.

## Design authority

`design:` commit `d798a22` approves this, including why it's sound: Nextflow stages an input under its original file name, so the staged name is exactly the CWL `basename`. That rationale was undocumented in Phase 1 and is now part of the locked design.

## Review fixes

- Basename artifacts now round-trip through parse and promote — a basename glob renders as a GString, and promotion is byte-identity bound, so this was an untested gap the story had declared as acceptance.
- The `val`-port rejection is now checked in every position the design claims (command, stream target, output glob), not just command position.
- `basename` registers as the kind introduced in schema version 4, so a payload declaring an older version while carrying it is rejected — previously the version integer gated nothing.
- `NfBasenameReference` joins `NfFlag` and `NfCommandToken` in the public API.
