### PR TITLE
Spec 1 follow-on: an edge is defined at its source, so !& belongs on outputs only

### DIFF
--- a/design_docs/core-refactor-design.md
+++ b/design_docs/core-refactor-design.md
@@ -258,15 +258,40 @@ A step-input value is currently a singleton dict with a magic key, dispatched by
 a `match` whose cases sit 143 lines apart. The sum type already exists; it is
 merely untyped. Made explicit:
 
-| Surface | AST node | Meaning |
-|---|---|---|
-| `!ii v` | `InlineLiteral(v)` | Literal value, never an edge |
-| `!& n` | `EdgeDef(n)` | Explicit edge definition site |
-| `!* n` | `EdgeRef(n)` | Explicit edge call site |
-| `!cwl e` | `RawCwlRef(e)` | **New.** Opaque CWL reference, passed through unresolved |
-| bare `s` | `UnresolvedName(s)` | Must resolve to a workflow input, else diagnostic |
+| Surface | AST node | Position | Meaning |
+|---|---|---|---|
+| `!ii v` | `InlineLiteral(v)` | `in:` | Literal value, never an edge |
+| `!* n` | `EdgeRef(n)` | `in:` | Explicit edge call site |
+| `!cwl e` | `RawCwlRef(e)` | `in:` | **New.** Opaque CWL reference, passed through unresolved |
+| bare `s` | `UnresolvedName(s)` | `in:` | Must resolve to a workflow input, else diagnostic |
+| `!& n` | `EdgeDef(n)` | **`out:` only** | Explicit edge definition site |
 
 Every node carries a source span. That is what buys the diagnostics.
+
+**Position is part of the type.** `EdgeDef` is reachable only through
+`OutputBinding.edge_def`; `InputValue` is the union of the four forms above and
+does not contain it. This is not a restriction added to the language — it is the
+language, finally written down. An edge is defined where its value comes into
+being, which is an output, and consumed where a value is needed, which is an
+input. Every `source:` CWL admits is a workflow input or `step/output`; a step's
+input port has no address, so an edge anchored there would have nothing for
+`!*` to resolve to.
+
+The first cut of this AST put all five forms in `InputValue`, mirroring YAML's
+willingness to anchor any node. The parser accepted `in: {f: !& n}` with no
+diagnostic and the compiler's input `match` had no case for it, so the value
+fell through to the raw-CWL default and earned `wic011` — advice to add `!ii`
+for a construct that was already correct and documented. Two lists of legal
+forms, in two files, with nothing linking them: the same shape as the
+`lang_version` validator gap. Recorded as CE-13, found by a generator derived
+from these types rather than from examples someone had seen work, and closed by
+narrowing the union so the position is a type error rather than a runtime
+fallthrough (`wic019`).
+
+The general rule this sets: **a form the union admits and no consumer
+implements is a promise the language cannot keep.** Where a form is genuinely
+pending — `!cwl` — the implementation-status table names it and a test asserts
+it still fails, so the exclusion cannot outlive its cause.
 
 **`--allow_raw_cwl`** operates on step-input *values*, a different axis from the
 key-level leak boundary. At baseline a bare string not found in `inputs:`

--- a/design_docs/core-refactor-design.md
+++ b/design_docs/core-refactor-design.md
@@ -286,7 +286,9 @@ forms, in two files, with nothing linking them: the same shape as the
 `lang_version` validator gap. Recorded as CE-13, found by a generator derived
 from these types rather than from examples someone had seen work, and closed by
 narrowing the union so the position is a type error rather than a runtime
-fallthrough (`wic019`).
+fallthrough. The diagnostic (`wic019`) is positional rather than
+input-specific: an edge definition outside an `out:` entry is reported wherever
+it appears, in either spelling, since §6.1 makes the two equivalent.
 
 The general rule this sets: **a form the union admits and no consumer
 implements is a promise the language cannot keep.** Where a form is genuinely

--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -181,18 +181,21 @@ out:
 - file: !& file_touch     # names it and defines an edge
 ```
 
+**This is the only place `!&` is legal.** An edge is defined where its value
+comes into being, and that is an output; §4.1.1 says why, and what to write
+instead if you meant to consume an edge.
+
 ---
 
 ## 4. Input values
 
-### 4.1 The five forms
+### 4.1 The four forms
 
-A step input is exactly one of these. There is no sixth form.
+A step input is exactly one of these. There is no fifth form.
 
 | Form | Written | Means |
 |---|---|---|
 | Inline literal | `f: !ii empty.txt` | A literal value. Never an edge. |
-| Edge definition | `f: !& name` | Defines an explicit edge at this point |
 | Edge reference | `f: !* name` | Consumes an edge defined elsewhere |
 | Raw CWL reference | `f: !cwl step/out` | Opaque to Sophios; passed through unresolved. **Not yet usable — awaits the Spec 3 compiler migration** |
 | Unresolved name | `f: some_input` | Must resolve to a workflow input |
@@ -214,18 +217,43 @@ the same as writing `!ii` — because a collection cannot name a workflow input,
 so a literal is its only possible meaning. The tag is still the recommended
 spelling: it states the intent instead of leaving it to be inferred.
 
-A tag outside the four above (`!foo`) is an error, not a fifth-and-a-half
+A tag outside the four above (`!foo`) is an error, not a fourth-and-a-half
 form. The loader has always rejected such documents, and the syntax layer
 must never accept more than the language it specifies.
 
-An **untagged mapping or sequence** in input position is an inline literal —
-the same as writing `!ii` — because a collection cannot name a workflow input,
-so a literal is its only possible meaning. The tag is still the recommended
-spelling: it states the intent instead of leaving it to be inferred.
+### 4.1.1 `!&` is not an input form
 
-A tag outside the four above (`!foo`) is an error, not a fifth-and-a-half
-form. The loader has always rejected such documents, and the syntax layer
-must never accept more than the language it specifies.
+`!&` defines an edge, and an edge is defined where its value comes into being
+— on an **output** (§3.3). Writing it in input position is an error
+(`wic019`), not a fifth form:
+
+```yaml
+in:
+  f: !& name        # error: !& defines an edge and belongs on an out: entry
+```
+
+Two reasons, and they agree.
+
+**A name has to name something.** Every `source:` Sophios emits is either a
+workflow input or `step/output` — those are the only two addresses CWL has. A
+step's *input port* has no address, so an edge anchored there would have
+nothing for `!*` to point at; resolving it would mean chasing back to whatever
+feeds that input, which is what you would have written in the first place.
+
+**Anchors define, aliases consume.** The notation is borrowed from YAML, where
+`&` names a node and `*` refers to one. Here the pairing follows the direction
+of dataflow: an output is where a value originates, so that is where it earns
+a name; an input is where a value arrives, already named upstream. Anchoring
+at a sink names something that is by definition already named.
+
+YAML itself permits an anchor on any node. Sophios is narrower than YAML here,
+deliberately — this is a language, not a schema over arbitrary YAML, and a
+construct that cannot be given a meaning is not one the grammar should admit.
+The parser reports the position with a span rather than leaving the compiler to
+guess at intent much later.
+
+If you meant to *consume* an edge, you want `!*`. If you meant to name this
+step's output, the `!&` belongs in its `out:` list.
 
 ### 4.2 Every name is bound once
 
@@ -297,7 +325,7 @@ and a **desugared** form, and they are equivalent:
 | Construct | Tagged | Desugared |
 |---|---|---|
 | Inline literal | `!ii value` | `{wic_inline_input: value}` |
-| Edge definition | `!& name` | `{wic_anchor: name}` |
+| Edge definition (`out:` only — §4.1.1) | `!& name` | `{wic_anchor: name}` |
 | Edge reference | `!* name` | `{wic_alias: name}` |
 | Raw CWL reference | `!cwl expr` | `{wic_raw_cwl: expr}` |
 

--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -217,15 +217,23 @@ the same as writing `!ii` — because a collection cannot name a workflow input,
 so a literal is its only possible meaning. The tag is still the recommended
 spelling: it states the intent instead of leaving it to be inferred.
 
-A tag outside the four above (`!foo`) is an error, not a fourth-and-a-half
-form. The loader has always rejected such documents, and the syntax layer
-must never accept more than the language it specifies.
+A tag outside the four above is an error, not a fourth-and-a-half form, but
+for two different reasons. An *unknown* tag (`!foo`) is `wic009`, and the
+loader has always rejected such documents too. `!&` is different: it is a
+known tag in the wrong position, so it is `wic019` (§4.1.1) and the loader
+does **not** reject it — `anchor_constructor` is registered unconditionally.
+The syntax layer is deliberately stricter than the loader here. It may never
+be more permissive; stricter is how a construct with no meaning stops being
+accepted.
 
 ### 4.1.1 `!&` is not an input form
 
 `!&` defines an edge, and an edge is defined where its value comes into being
-— on an **output** (§3.3). Writing it in input position is an error
-(`wic019`), not a fifth form:
+— on an **output** (§3.3). That is a rule about *position*, not about inputs:
+an edge definition anywhere other than an `out:` entry is `wic019`, whether it
+appears in an `in:` binding, inside an `!ii` payload, in the `wic:` block, or
+at the top level. Both spellings are treated alike, since §6.1 makes them
+equivalent.
 
 ```yaml
 in:

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -50,6 +50,7 @@ class Code(StrEnum):
     MISSING_INPUT_FILE = 'wic016'
     UNKNOWN_LANG_VERSION = 'wic017'
     LANG_VERSION_CONFLICT = 'wic018'
+    EDGE_DEF_IN_INPUT = 'wic019'
     RECURSIVE_ALIAS = 'wic030'
 
 

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -50,7 +50,7 @@ class Code(StrEnum):
     MISSING_INPUT_FILE = 'wic016'
     UNKNOWN_LANG_VERSION = 'wic017'
     LANG_VERSION_CONFLICT = 'wic018'
-    EDGE_DEF_IN_INPUT = 'wic019'
+    MISPLACED_EDGE_DEF = 'wic019'
     RECURSIVE_ALIAS = 'wic030'
 
 

--- a/src/sophios/lang/nodes.py
+++ b/src/sophios/lang/nodes.py
@@ -31,7 +31,7 @@ class Shape(StrEnum):
     INTERNAL = 'internal'
     #: The node's own name, carried by its position rather than a key.
     IDENTITY = 'identity'
-    #: `in:` — a mapping of input name to one of the five input forms.
+    #: `in:` — a mapping of input name to one of the four input forms.
     INPUT_BINDINGS = 'input_bindings'
     #: `out:` — a sequence of bare names or single-key edge bindings.
     OUTPUT_BINDINGS = 'output_bindings'
@@ -111,7 +111,14 @@ class InlineLiteral:
 
 @dataclass(frozen=True, slots=True)
 class EdgeDef:
-    """`!& name` — an explicit edge definition site."""
+    """`!& name` — an explicit edge definition site.
+
+    Legal only where a value comes into being: an output. Reachable only
+    through `OutputBinding.edge_def` — it is not a member of `InputValue`, so
+    it cannot appear on an input, nested inside a literal, or anywhere else
+    `OpaqueCwl` reaches. `!&` written in input position is not this node; the
+    parser reports it as `wic019` instead (§4.1.1).
+    """
 
     name: str = surface(Shape.IDENTITY)
     span: SourceSpan = surface(Shape.INTERNAL)
@@ -149,10 +156,15 @@ class UnresolvedName:
     span: SourceSpan = surface(Shape.INTERNAL)
 
 
-#: The complete set of forms a step input may take. Closed by construction:
+#: The complete set of forms a step input may take — exactly the four forms
+#: of §4.1: a literal, an edge reference, a raw CWL reference, or an
+#: unresolved name. There is no fifth. Position is part of the type: `EdgeDef`
+#: is deliberately not a member, because an edge is defined where its value
+#: comes into being, which is an output, not an input (§4.1.1) — it is
+#: reachable only through `OutputBinding.edge_def`. Closed by construction:
 #: the parser produces nothing outside this union, so exhaustive `match`
 #: statements over it stay exhaustive.
-InputValue: TypeAlias = InlineLiteral | EdgeDef | EdgeRef | RawCwlRef | UnresolvedName
+InputValue: TypeAlias = InlineLiteral | EdgeRef | RawCwlRef | UnresolvedName
 
 #: CWL that Sophios does not interpret and passes through unchanged — but no
 #: longer `Any`: a closed recursive union of exactly what YAML's safe schema

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -333,8 +333,23 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     because a constructor that re-emitted its own tag would fire again on
     reload. An untagged scalar is an `UnresolvedName`, which resolution later
     binds to a workflow input or reports on.
+
+    `!&`/`wic_anchor` — in either spelling — is checked first and separately:
+    it is a known tag, just in the wrong position (§4.1.1), so it must be
+    diagnosed as `wic019` rather than mistaken for `wic009 UNKNOWN_TAG` or
+    silently accepted as an inline literal.
     """
     span = SourceSpan.of(file, node)
+
+    edge = _out_edge_def(node, file, diags)
+    if edge is not None:
+        diags.error(
+            Code.EDGE_DEF_IN_INPUT,
+            "'!&' defines an edge, and an edge is defined on an output, not an input (§4.1.1); "
+            "use '!*' here to consume an edge, or move '!&' to this step's out: list to define one",
+            span,
+        )
+        return UnresolvedName(edge.name, span)
 
     build = Forms.TAGGED.get(node.tag)
     if build is not None:
@@ -383,18 +398,20 @@ class Forms:  # pylint: disable=too-few-public-methods  # a namespace, not a typ
     recorded. Both tables are read-only views.
     """
 
-    #: Tagged spellings — what people write.
+    #: Tagged spellings — what people write. `!&` (`Tag.ANCHOR`) is
+    #: deliberately absent: it is legal only on an `out:` entry, and
+    #: `_input_value` checks for it — via `_out_edge_def` — before this table
+    #: is ever consulted, so it never reaches here as an input (§4.1.1).
     TAGGED: Final[Mapping[str, Builder]] = MappingProxyType({
         Tag.INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_literal(n, f, d), s, text=_literal_text(n)),
-        Tag.ANCHOR: lambda n, f, d, s: EdgeDef(_name_text(n, f, d), s),
         Tag.ALIAS: lambda n, f, d, s: EdgeRef(_name_text(n, f, d), s),
         Tag.RAW_CWL: lambda n, f, d, s: RawCwlRef(_name_text(n, f, d), s),
     })
 
-    #: Desugared spellings — what tooling emits.
+    #: Desugared spellings — what tooling emits. `wic_anchor` (`Key.ANCHOR`)
+    #: is absent for the same reason as `Tag.ANCHOR` above.
     DESUGARED: Final[Mapping[str, Builder]] = MappingProxyType({
         Key.INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_opaque(n, f, d), s),
-        Key.ANCHOR: lambda n, f, d, s: EdgeDef(_name_text(n, f, d), s),
         Key.ALIAS: lambda n, f, d, s: EdgeRef(_name_text(n, f, d), s),
         Key.RAW_CWL: lambda n, f, d, s: RawCwlRef(_name_text(n, f, d), s),
     })
@@ -612,6 +629,11 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
         # the tag silently. Scalar `!ii` routes the same way; collection `!ii`
         # is handled below, on the materialised content, because its builder
         # would call back into this walk on the very same node.
+        #
+        # `!&` buried in otherwise-opaque content is still not an input form
+        # (§4.1.1): `_input_value` reports `wic019` for it here exactly as it
+        # would at the top of an `in:` binding, rather than letting it become
+        # an `EdgeDef` — a node `OpaqueCwl` no longer admits.
         return _input_value(node, file, diags)
 
     content: OpaqueCwl

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -341,15 +341,17 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     """
     span = SourceSpan.of(file, node)
 
-    edge = _out_edge_def(node, file, diags)
-    if edge is not None:
+    if _is_edge_def(node):
+        # Reported before the name is read, so a malformed name does not earn
+        # `wic005` advice on how to spell something the reader is then told
+        # they may not write here at all.
         diags.error(
-            Code.EDGE_DEF_IN_INPUT,
-            "'!&' defines an edge, and an edge is defined on an output, not an input (§4.1.1); "
-            "use '!*' here to consume an edge, or move '!&' to this step's out: list to define one",
+            Code.MISPLACED_EDGE_DEF,
+            "'!&' defines an edge, and an edge is defined where its value comes into being: "
+            "a step's out: entry (§4.1.1). Use '!*' to consume an edge",
             span,
         )
-        return UnresolvedName(edge.name, span)
+        return UnresolvedName('', span)
 
     build = Forms.TAGGED.get(node.tag)
     if build is not None:
@@ -366,6 +368,25 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     # A bare mapping or sequence cannot name a workflow input, so it is only
     # meaningful as a literal.
     return InlineLiteral(_opaque(node, file, diags), span)
+
+
+def _is_edge_def(node: yaml.nodes.Node) -> bool:
+    """Whether `node` spells an edge definition, in either surface form.
+
+    Both spellings, because §6.1 makes them equivalent and a rule that caught
+    only the tagged one would let the desugared one through in exactly the
+    positions the tagged one is refused — two surfaces, one language, two
+    answers, which is the divergence CE-02 was about.
+
+    Position is not consulted: an edge definition is legal only in a step's
+    `out:` list, which `_out_edge_def` handles on its own path and never
+    reaches here.
+    """
+    if node.tag == Tag.ANCHOR:
+        return True
+    return (isinstance(node, yaml.nodes.MappingNode)
+            and len(node.value) == 1
+            and getattr(node.value[0][0], 'value', None) == Key.ANCHOR)
 
 
 def _desugared_form(
@@ -620,6 +641,13 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics,
     path = _path | {id(node)}
 
     _reject_unknown_tag(node, file, diags)
+
+    if _is_edge_def(node):
+        # Both spellings, in every position `_opaque` walks. Catching only the
+        # tagged one would let `{wic_anchor: n}` through exactly where `!& n`
+        # is refused, which is the two-surfaces-one-language divergence CE-02
+        # was about. `out:` never reaches here — `_out_edge_def` owns it.
+        return _input_value(node, file, diags)
 
     if node.tag in (Tag.ANCHOR, Tag.ALIAS, Tag.RAW_CWL) or (
             node.tag == Tag.INLINE_INPUT and isinstance(node, yaml.nodes.ScalarNode)):

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -334,24 +334,35 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     reload. An untagged scalar is an `UnresolvedName`, which resolution later
     binds to a workflow input or reports on.
 
-    `!&`/`wic_anchor` — in either spelling — is checked first and separately:
-    it is a known tag, just in the wrong position (§4.1.1), so it must be
-    diagnosed as `wic019` rather than mistaken for `wic009 UNKNOWN_TAG` or
-    silently accepted as an inline literal.
+    `!&`/`wic_anchor` — in either spelling — is checked separately: it is a
+    known tag, just in the wrong position (§4.1.1), so it must be diagnosed as
+    `wic019` rather than mistaken for `wic009 UNKNOWN_TAG` or silently
+    accepted as an inline literal.
     """
     span = SourceSpan.of(file, node)
 
+    # Tag check first, in the same order `_opaque` uses. A node can be both
+    # unknown-tagged and a misplaced anchor (`!foo {wic_anchor: x}`), and the
+    # two positions must reach the same verdict — checking the anchor first
+    # here would report `wic019` alone in input position while passthrough
+    # reported both, which is the two-surfaces-one-language divergence this
+    # rule exists to prevent.
+    _reject_unknown_tag(node, file, diags, span)
+
     if _is_edge_def(node):
-        # Reported before the name is read, so a malformed name does not earn
-        # `wic005` advice on how to spell something the reader is then told
-        # they may not write here at all.
+        # The diagnostic comes before the name is read, so a *malformed* name
+        # earns no `wic005` advice on spelling something the reader is then
+        # told they may not write here at all. A well-formed name is still
+        # kept: the AST preserves what it was given, and recovery that
+        # discards a name the source supplied is the silent drop a total
+        # parser must never make.
         diags.error(
             Code.MISPLACED_EDGE_DEF,
             "'!&' defines an edge, and an edge is defined where its value comes into being: "
             "a step's out: entry (§4.1.1). Use '!*' to consume an edge",
             span,
         )
-        return UnresolvedName('', span)
+        return UnresolvedName(_recovered_edge_name(node), span)
 
     build = Forms.TAGGED.get(node.tag)
     if build is not None:
@@ -368,6 +379,23 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     # A bare mapping or sequence cannot name a workflow input, so it is only
     # meaningful as a literal.
     return InlineLiteral(_opaque(node, file, diags), span)
+
+
+def _recovered_edge_name(node: yaml.nodes.Node) -> str:
+    """The name a misplaced edge definition carried, for recovery.
+
+    Read without diagnosing: the construct is already reported, and a second
+    complaint about how its name is spelled helps nobody. A scalar carries its
+    text in either spelling; a collection has no name to keep, so the empty
+    string is the honest answer there rather than an invented one.
+    """
+    target = node
+    if isinstance(node, yaml.nodes.MappingNode) and len(node.value) == 1:
+        target = node.value[0][1]
+    if not isinstance(target, yaml.nodes.ScalarNode):
+        return ''
+    text: str = target.value
+    return text
 
 
 def _is_edge_def(node: yaml.nodes.Node) -> bool:

--- a/src/sophios/lang/render.py
+++ b/src/sophios/lang/render.py
@@ -130,7 +130,17 @@ class _Writer:
         """One `out:` entry: a bare name, or a name bound to an edge."""
         if binding.edge_def is None:
             return binding.name
-        return {binding.name: self.input_value(binding.edge_def)}
+        return {binding.name: self.edge_def(binding.edge_def)}
+
+    def edge_def(self, edge: EdgeDef) -> Any:
+        """Spell an `!&` edge definition — legal only on an `out:` entry (§4.1.1).
+
+        `EdgeDef` is not a member of `InputValue`, so this is a sibling of
+        `input_value` rather than one of its cases: the only caller is
+        `output`, and `plain`'s walk over `OpaqueCwl` never reaches an
+        `EdgeDef` either, for the same reason.
+        """
+        return _Tagged(Tag.ANCHOR, edge.name) if self.mode == 'tagged' else {Key.ANCHOR: edge.name}
 
     def sidecar(self, sidecar: WicSidecar) -> Any:
         """A `wic:` block, restoring its `(index, name)` step keys.
@@ -153,8 +163,6 @@ class _Writer:
         match value:
             case InlineLiteral():
                 return self._literal(value)
-            case EdgeDef(name=name):
-                return _Tagged(Tag.ANCHOR, name) if self.mode == 'tagged' else {Key.ANCHOR: name}
             case EdgeRef(name=name):
                 return _Tagged(Tag.ALIAS, name) if self.mode == 'tagged' else {Key.ALIAS: name}
             case RawCwlRef(expression=expression):
@@ -182,7 +190,7 @@ class _Writer:
         if isinstance(literal.value, (list, dict)):
             return _Tagged(Tag.INLINE_INPUT, self.plain(literal.value))
 
-        if isinstance(literal.value, (InlineLiteral, EdgeDef, EdgeRef, RawCwlRef, UnresolvedName)):
+        if isinstance(literal.value, (InlineLiteral, EdgeRef, RawCwlRef, UnresolvedName)):
             # A construct as the direct payload has no tagged spelling — two
             # tags cannot share a node — so the desugared form carries it.
             return {Key.INLINE_INPUT: self.plain(literal.value)}
@@ -202,7 +210,7 @@ class _Writer:
         forgotten node kind reaches the dumper as a live dataclass.
         """
         match value:
-            case InlineLiteral() | EdgeDef() | EdgeRef() | RawCwlRef() | UnresolvedName():
+            case InlineLiteral() | EdgeRef() | RawCwlRef() | UnresolvedName():
                 return self.input_value(value)
             case dict():
                 return {k: self.plain(v) for k, v in value.items()}

--- a/src/sophios/lang/schema.py
+++ b/src/sophios/lang/schema.py
@@ -217,22 +217,25 @@ def _wic_block() -> dict[str, Any]:
 
 
 def _input_value() -> dict[str, Any]:
-    """One of the five input forms (§4.1).
+    """One of the four input forms (§4.1). There is no fifth.
 
     Unconstrained on purpose. A mapping whose single key is a construct key is
     a construct; any other value is an inline literal or an unresolved name,
     and the parser accepts all of them. `construct` is referenced so editors
-    can offer the four keys as completions.
+    can offer the three input-position keys as completions — `wic_anchor` is
+    not among them: `!&` defines an edge, which is legal only on an `out:`
+    entry (§4.1.1), so `Forms.DESUGARED` — and therefore this schema — never
+    offers it in input position.
     """
     return {
-        'description': 'An inline literal, edge definition, edge reference, '
+        'description': 'An inline literal, edge reference, '
                        'raw CWL reference, or unresolved name (§4.1).',
         'anyOf': [{'$ref': '#/$defs/construct'}, {}],
     }
 
 
 def _construct() -> dict[str, Any]:
-    """A desugared Sophios construct: a single-key mapping.
+    """A desugared Sophios construct valid in input position: a single-key mapping.
 
     Derived from the parser's dispatch table, so a construct added there
     appears here without anyone remembering to update a schema.

--- a/src/sophios/schemas/wic_schema.py
+++ b/src/sophios/schemas/wic_schema.py
@@ -466,7 +466,14 @@ def wic_main_schema(tools_cwl: Tools, yml_stems: list[str], schema_store: dict[s
     if not hypothesis:
         in_schema: Json = {}
         in_schema['type'] = 'object'
-        in_schema['additionalProperties'] = True
+        # An `in:` value may be any CWL, so the shape stays open — except for
+        # `wic_anchor`. `!&` defines an edge, and an edge is defined at its
+        # source, which is an `out:` entry (reference §4.1.1); the parser
+        # reports wic019 for it here. Leaving this open would make the
+        # validator the *permissive* side of the pair, accepting what the
+        # language rejects — the mirror of the gap where this schema rejected
+        # a `lang_version` tag the parser accepted.
+        in_schema['additionalProperties'] = {'not': {'required': ['wic_anchor']}}
         in_schema['properties'] = {'script': str_nonempty}
 
         # See utils_yaml.py

--- a/src/sophios/schemas/wic_schema.py
+++ b/src/sophios/schemas/wic_schema.py
@@ -466,14 +466,13 @@ def wic_main_schema(tools_cwl: Tools, yml_stems: list[str], schema_store: dict[s
     if not hypothesis:
         in_schema: Json = {}
         in_schema['type'] = 'object'
-        # An `in:` value may be any CWL, so the shape stays open — except for
-        # `wic_anchor`. `!&` defines an edge, and an edge is defined at its
-        # source, which is an `out:` entry (reference §4.1.1); the parser
-        # reports wic019 for it here. Leaving this open would make the
-        # validator the *permissive* side of the pair, accepting what the
-        # language rejects — the mirror of the gap where this schema rejected
-        # a `lang_version` tag the parser accepted.
-        in_schema['additionalProperties'] = {'not': {'required': ['wic_anchor']}}
+        # No `wic_anchor` exclusion here. The `in:` schema a workflow actually
+        # validates against is built by `_cwl_schema_inputs_props`, which
+        # composes each tool input from `str_nonempty | alias | ii` and has
+        # never admitted the anchor — `_cwl_schema_out_tag` is the only place
+        # that does (d3b08ee, "move wic_anchor !& to out: tag"). So the
+        # validator already agrees with §4.1.1, by an older route.
+        in_schema['additionalProperties'] = True
         in_schema['properties'] = {'script': str_nonempty}
 
         # See utils_yaml.py

--- a/tests/core/provocations.py
+++ b/tests/core/provocations.py
@@ -30,6 +30,7 @@ PARSE: Final[dict[Code, str]] = {
     Code.UNKNOWN_TAG: 'top: !foo bar\n',
     Code.DUPLICATE_KEY: 'steps:\n- id: s\n  in:\n    f: !ii a\n    f: !ii b\n',
     Code.RECURSIVE_ALIAS: 'top: &a [*a]\n',
+    Code.EDGE_DEF_IN_INPUT: 'steps:\n- id: s\n  in:\n    f: !& e\n',
 }
 
 #: Codes provoked through the compiler or its helpers. Callables raise

--- a/tests/core/provocations.py
+++ b/tests/core/provocations.py
@@ -30,7 +30,7 @@ PARSE: Final[dict[Code, str]] = {
     Code.UNKNOWN_TAG: 'top: !foo bar\n',
     Code.DUPLICATE_KEY: 'steps:\n- id: s\n  in:\n    f: !ii a\n    f: !ii b\n',
     Code.RECURSIVE_ALIAS: 'top: &a [*a]\n',
-    Code.EDGE_DEF_IN_INPUT: 'steps:\n- id: s\n  in:\n    f: !& e\n',
+    Code.MISPLACED_EDGE_DEF: 'top: !& e\n',
 }
 
 #: Codes provoked through the compiler or its helpers. Callables raise

--- a/tests/core/strategies.py
+++ b/tests/core/strategies.py
@@ -28,7 +28,11 @@ scalar_payload_texts = st.sampled_from([
 ])
 
 #: Construct leaves that may appear nested inside an `!ii` payload.
-construct_payload_texts = st.sampled_from(['!* e', '!& d', '!cwl a/b', '{wic_anchor: n}'])
+#: `!& d` and `{wic_anchor: n}` are absent: `OpaqueCwl` contains `InputValue`,
+#: which no longer admits `EdgeDef`, so an anchor nested in a literal payload
+#: is reported (wic019) exactly as one in input position is. An anchor is
+#: only meaningful on an `out:` entry, where nothing can be nested inside it.
+construct_payload_texts = st.sampled_from(['!* e', '!cwl a/b', '{wic_alias: n}'])
 
 #: Recursive payload text over the closed OpaqueCwl union: scalars, nested
 #: constructs, and flow collections of both. Derived from what the type
@@ -62,21 +66,21 @@ def input_lines(draw: st.DrawFn, name: str | None = None, indent: str = '      '
     """
     # pylint: disable=too-many-return-statements  # one return per surface form
     name = draw(identifiers) if name is None else name
-    form = draw(st.sampled_from(['ii', 'anchor', 'alias', 'cwl', 'bare',
-                                 'ii_desugared', 'anchor_desugared', 'alias_desugared', 'cwl_desugared']))
+    # No 'anchor' form: `!&` defines an edge and is legal only on an `out:`
+    # entry (reference §4.1.1), so an input carrying one is not a well-formed
+    # document. `_out_lines` below still generates both of its spellings, so
+    # edge definitions stay covered where they belong.
+    form = draw(st.sampled_from(['ii', 'alias', 'cwl', 'bare',
+                                 'ii_desugared', 'alias_desugared', 'cwl_desugared']))
     match form:
         case 'ii':
             return f'{indent}{name}: !ii {draw(opaque_payload_texts)}'
-        case 'anchor':
-            return f'{indent}{name}: !& {draw(identifiers)}'
         case 'alias':
             return f'{indent}{name}: !* {draw(identifiers)}'
         case 'cwl':
             return f'{indent}{name}: !cwl {draw(identifiers)}/{draw(identifiers)}'
         case 'ii_desugared':
             return f'{indent}{name}: {{wic_inline_input: {draw(desugared_payload_texts)}}}'
-        case 'anchor_desugared':
-            return f'{indent}{name}: {{wic_anchor: {draw(identifiers)}}}'
         case 'alias_desugared':
             return f'{indent}{name}: {{wic_alias: {draw(identifiers)}}}'
         case 'cwl_desugared':

--- a/tests/core/strategies.py
+++ b/tests/core/strategies.py
@@ -28,10 +28,10 @@ scalar_payload_texts = st.sampled_from([
 ])
 
 #: Construct leaves that may appear nested inside an `!ii` payload.
-#: `!& d` and `{wic_anchor: n}` are absent: `OpaqueCwl` contains `InputValue`,
-#: which no longer admits `EdgeDef`, so an anchor nested in a literal payload
-#: is reported (wic019) exactly as one in input position is. An anchor is
-#: only meaningful on an `out:` entry, where nothing can be nested inside it.
+#: Neither spelling of an edge definition appears here. An edge is defined on
+#: an `out:` entry and nowhere else (reference §4.1.1), so `!& d` and
+#: `{wic_anchor: n}` both earn wic019 in a payload — `_out_lines` below
+#: generates both spellings in the one position they are legal.
 construct_payload_texts = st.sampled_from(['!* e', '!cwl a/b', '{wic_alias: n}'])
 
 #: Recursive payload text over the closed OpaqueCwl union: scalars, nested

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -184,7 +184,6 @@ def test_corpus_is_not_empty() -> None:
 @pytest.mark.fast
 @given(
     st.sampled_from([('!ii', 'wic_inline_input', InlineLiteral),
-                     ('!&', 'wic_anchor', EdgeDef),
                      ('!*', 'wic_alias', EdgeRef),
                      ('!cwl', 'wic_raw_cwl', RawCwlRef)]),
     identifiers,
@@ -208,6 +207,26 @@ def test_surface_forms_are_equivalent(form: tuple[str, str, type], payload: str)
     right = sugared.document.steps[0].inputs[0][1]
     assert isinstance(left, expected) and isinstance(right, expected)
     assert _payload(left) == _payload(right)
+
+
+@pytest.mark.fast
+@given(identifiers)
+@FAST
+def test_the_two_spellings_of_an_edge_definition_agree_on_an_output(payload: str) -> None:
+    """`!&` has the same two spellings as its siblings, in the one position it
+    is legal (§4.1.1). Tested separately rather than as a fourth row above,
+    because that table quantifies over *input* position and an anchor there is
+    now `wic019` — the case does not disappear, it moves to where it belongs.
+    """
+    tagged = parse(f'steps:\n- id: s\n  out:\n  - f: !& {payload}\n', 'a.wic')
+    sugared = parse(f'steps:\n- id: s\n  out:\n  - f:\n      wic_anchor: {payload}\n', 'b.wic')
+    assert tagged.ok and sugared.ok
+    assert tagged.document is not None and sugared.document is not None
+
+    left = tagged.document.steps[0].outputs[0].edge_def
+    right = sugared.document.steps[0].outputs[0].edge_def
+    assert isinstance(left, EdgeDef) and isinstance(right, EdgeDef)
+    assert left.name == right.name == payload
 
 
 def _payload(value: InputValue) -> Any:
@@ -290,6 +309,15 @@ class Reported(NamedTuple):
 
 
 REPORTED: Final[tuple[Reported, ...]] = (
+    Reported('an edge definition in input position names the position (§4.1.1)',
+             'steps:\n- id: s\n  in:\n    f: !& e\n',
+             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
+    Reported('the desugared spelling is reported the same way',
+             'steps:\n- id: s\n  in:\n    f: {wic_anchor: e}\n',
+             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
+    Reported('an anchor nested in a literal payload is reported too',
+             'steps:\n- id: s\n  in:\n    f: !ii {k: !& e}\n',
+             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
     Reported('a collection step key is reported, not stringified',
              'steps:\n  ? [a, b]\n  : {}\n', Code.EXPECTED_SCALAR, 2,
              message_contains='mapping keys must be scalars'),
@@ -400,7 +428,10 @@ def test_python_api_emits_documents_this_parser_accepts() -> None:
     'top: !foo bar\n',
     'top: !foo {a: 1}\n',
     'top: !foo [1, 2]\n',
-    'steps:\n- id: s\n  in:\n    a: !foo {wic_anchor: x}\n',
+    # A still-legal desugared key: the claim is that !foo reports wic009 even
+    # when it wraps a construct, and wic_anchor in input position is now itself
+    # an error (wic019), which would confound the probe.
+    'steps:\n- id: s\n  in:\n    a: !foo {wic_alias: x}\n',
 ], ids=['input-pos', 'scalar', 'mapping', 'sequence', 'over-desugared'])
 def test_unknown_tags_report_wic009(source: str) -> None:
     """The code contract: an unknown tag reports wic009, in every position.

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -35,7 +35,7 @@ from sophios.lang import (
     parse,
 )
 from sophios.lang.spans import SourceSpan
-from sophios.utils_yaml import wic_loader
+from sophios.utils_yaml import Key, wic_loader
 
 from . import provocations
 from .wic_corpus import CORPUS, corpus_id
@@ -686,15 +686,24 @@ def test_tag_decisions_agree_across_positions(tag: str, shape: str, data: st.Dat
     swallowed in input position — two paths, one language, two answers. This
     pins the agreement for every tag and payload shape the generator makes.
     """
-    payload = data.draw(identifiers) if shape == 'scalar' else f'{{{data.draw(identifiers)}: x}}'
+    # The mapping key is drawn from the construct keys as well as arbitrary
+    # identifiers. `identifiers` caps at eight characters and every desugared
+    # key is longer, so without this union the generator could not produce
+    # `!foo {wic_anchor: x}` — the one payload where the two positions once
+    # disagreed — and the property was green over a space missing its own
+    # motivating case.
+    key = data.draw(st.one_of(identifiers, st.sampled_from(sorted(Key.ALL))))
+    payload = data.draw(identifiers) if shape == 'scalar' else f'{{{key}: x}}'
     value = f'{tag}{payload}'
 
     in_position = parse(f'steps:\n- id: s\n  in:\n    a: {value}\n', 'pos.wic')
     passthrough = parse(f'top: {value}\n', 'pos.wic')
 
-    reported_in = any(d.code is Code.UNKNOWN_TAG for d in in_position.diagnostics)
-    reported_through = any(d.code is Code.UNKNOWN_TAG for d in passthrough.diagnostics)
-    assert reported_in == reported_through, f'{value!r}: input={reported_in}, passthrough={reported_through}'
+    codes_in = {d.code for d in in_position.diagnostics}
+    codes_through = {d.code for d in passthrough.diagnostics}
+    assert codes_in == codes_through, (
+        f'{value!r}: input={sorted(c.value for c in codes_in)}, '
+        f'passthrough={sorted(c.value for c in codes_through)}')
 
 
 @pytest.mark.fast
@@ -826,3 +835,53 @@ def test_lang_layer_depends_only_on_stdlib_and_pyyaml() -> None:
                 roots = [node.module.split('.')[0]]
             for root in roots:
                 assert root in allowed, f'{source_file.name} imports {root!r} — the lang layer must stay standalone'
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('source, expected', [
+    ('steps:\n- id: s\n  in:\n    f: !& e\n', 'e'),
+    ('steps:\n- id: s\n  in:\n    f: {wic_anchor: e}\n', 'e'),
+    ('top: !& x\n', 'x'),
+    ('steps:\n- id: s\n  in:\n    f: !& [a]\n', ''),
+], ids=['tagged', 'desugared', 'passthrough', 'collection has no name'])
+def test_a_misplaced_edge_definition_keeps_the_name_it_was_given(
+        source: str, expected: str) -> None:
+    """Recovery preserves the name, in both spellings and every position.
+
+    `_output_binding` states the rule this follows: the AST preserves what it
+    was given, and a silent drop is the one thing a total parser must never
+    do. Reporting the construct is not a licence to discard the name it
+    carried — a caller rendering the recovered AST would otherwise emit `''`
+    where the source said `e`. A collection genuinely has no name to keep, so
+    the empty string is honest there rather than invented.
+    """
+    result = parse(source, 'keep.wic')
+    assert result.document is not None
+    step = result.document.steps[0] if result.document.steps else None
+    value = step.inputs[0][1] if step else result.document.passthrough[0][1]
+    assert isinstance(value, UnresolvedName)
+    assert value.name == expected
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('payload, expected', [
+    ('{wic_anchor: x}', {Code.UNKNOWN_TAG, Code.MISPLACED_EDGE_DEF}),
+    ('{wic_alias: x}', {Code.UNKNOWN_TAG}),
+    ('bar', {Code.UNKNOWN_TAG}),
+], ids=['anchor payload', 'alias payload', 'scalar payload'])
+def test_an_unknown_tag_and_a_misplaced_anchor_are_both_reported_in_both_positions(
+        payload: str, expected: set) -> None:
+    """A node can be two things wrong at once, and both positions must say so.
+
+    `!foo {wic_anchor: x}` is an unknown tag *and* a misplaced edge
+    definition. `_input_value` used to return on the anchor before reaching
+    the tag check while `_opaque` checked the tag first, so input position
+    reported one code and passthrough reported two — the same construct, two
+    verdicts. The property above cannot be relied on alone to catch this:
+    until its payload keys were widened it could not spell `wic_anchor`.
+    """
+    in_position = parse(f'steps:\n- id: s\n  in:\n    a: !foo {payload}\n', 'both.wic')
+    passthrough = parse(f'top: !foo {payload}\n', 'both.wic')
+
+    assert {d.code for d in in_position.diagnostics} == expected
+    assert {d.code for d in passthrough.diagnostics} == expected

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -311,13 +311,24 @@ class Reported(NamedTuple):
 REPORTED: Final[tuple[Reported, ...]] = (
     Reported('an edge definition in input position names the position (§4.1.1)',
              'steps:\n- id: s\n  in:\n    f: !& e\n',
-             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
+             Code.MISPLACED_EDGE_DEF, 4, message_contains='out:'),
     Reported('the desugared spelling is reported the same way',
              'steps:\n- id: s\n  in:\n    f: {wic_anchor: e}\n',
-             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
+             Code.MISPLACED_EDGE_DEF, 4, message_contains='out:'),
     Reported('an anchor nested in a literal payload is reported too',
              'steps:\n- id: s\n  in:\n    f: !ii {k: !& e}\n',
-             Code.EDGE_DEF_IN_INPUT, 4, message_contains='out:'),
+             Code.MISPLACED_EDGE_DEF, 4, message_contains='out:'),
+    Reported('the rule is positional: an anchor at the top level is reported',
+             'top: !& e\n', Code.MISPLACED_EDGE_DEF, 1, message_contains='out:'),
+    Reported('and inside the wic: block, which is not a step at all',
+             'wic:\n  graphviz:\n    label: !& e\n',
+             Code.MISPLACED_EDGE_DEF, 3, message_contains='out:'),
+    Reported('the desugared spelling is reported in the same positions (§6.1)',
+             'top: {wic_anchor: e}\n', Code.MISPLACED_EDGE_DEF, 1, message_contains='out:'),
+    Reported('a malformed name does not earn spelling advice for a construct '
+             'that may not appear here at all',
+             'steps:\n- id: s\n  in:\n    f: !& [a]\n',
+             Code.MISPLACED_EDGE_DEF, 4, message_contains='out:'),
     Reported('a collection step key is reported, not stringified',
              'steps:\n  ? [a, b]\n  : {}\n', Code.EXPECTED_SCALAR, 2,
              message_contains='mapping keys must be scalars'),
@@ -684,6 +695,42 @@ def test_tag_decisions_agree_across_positions(tag: str, shape: str, data: st.Dat
     reported_in = any(d.code is Code.UNKNOWN_TAG for d in in_position.diagnostics)
     reported_through = any(d.code is Code.UNKNOWN_TAG for d in passthrough.diagnostics)
     assert reported_in == reported_through, f'{value!r}: input={reported_in}, passthrough={reported_through}'
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('spelling', ['!& e', '{wic_anchor: e}'], ids=['tagged', 'desugared'])
+@pytest.mark.parametrize('position, source', [
+    ('input', 'steps:\n- id: s\n  in:\n    f: {value}\n'),
+    ('nested in a literal', 'steps:\n- id: s\n  in:\n    f: !ii {{k: {value}}}\n'),
+    ('step passthrough', 'steps:\n- id: s\n  label: {value}\n'),
+    ('top level', 'top: {value}\n'),
+    ('wic block', 'wic:\n  graphviz:\n    label: {value}\n'),
+])
+def test_an_edge_definition_is_refused_in_every_position_but_out(
+        spelling: str, position: str, source: str) -> None:
+    """One construct, one verdict, in both spellings and every position.
+
+    The narrower unknown-tag version above quantifies only over
+    `Code.UNKNOWN_TAG`, so it cannot see a `wic019` divergence — and there was
+    one: `_opaque` routed on the tag, so `{wic_anchor: e}` was plain data
+    exactly where `!& e` was refused.
+    """
+    result = parse(source.format(value=spelling), 'pos.wic')
+    assert any(d.code is Code.MISPLACED_EDGE_DEF for d in result.diagnostics), (
+        f'{spelling!r} in {position} was accepted')
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('spelling, source', [
+    ('tagged', 'steps:\n- id: s\n  out:\n  - f: !& e\n'),
+    ('desugared', 'steps:\n- id: s\n  out:\n  - f:\n      wic_anchor: e\n'),
+])
+def test_and_accepted_in_the_one_position_it_belongs(spelling: str, source: str) -> None:
+    """The other half: refusing everywhere would satisfy the test above."""
+    result = parse(source, 'pos.wic')
+    assert not list(result.diagnostics), f'{spelling} on out: was refused'
+    assert result.document is not None
+    assert result.document.steps[0].outputs[0].edge_def is not None
 
 
 @pytest.mark.fast


### PR DESCRIPTION
`in: {f: !& n}` parsed clean into an `EdgeDef`. The compiler's `match` over an `in:` value has arms for `wic_alias` and `wic_inline_input` and none for `wic_anchor` — that lives only in the `out:` walk — so the value fell through to the raw-CWL default and earned `wic011`: advice to write `!ii` for a construct §4.1 listed as one of five valid input forms. The same tag on an output compiles.

I'm treating this as a grammar defect rather than a compiler gap. An anchor names a value where it comes into being: an output is where a value originates, an input is where one arrives already named upstream. CWL agrees independently — every `source:` it admits is a workflow input or `step/output`, so a step's input port has no address for `!*` to resolve to. YAML anchors any node, but a language doesn't owe a construct a meaning just because its serialisation format admits the syntax.

So `EdgeDef` leaves the `InputValue` union and position becomes part of the type: reachable only through `OutputBinding.edge_def`, with `wic019` reported at the span, naming both remedies.

**Compatibility.** No `.wic` in `docs/tutorials`, `examples`, `mm-workflows` or `image-workflows` uses the construct, and it has never compiled. The `!` marks the language narrowing, not a change to any working workflow.

**Worth a look:**

- The rule is **positional**, not input-specific: an edge definition outside an `out:` entry is reported wherever it appears — in an `in:` binding, nested in an `!ii` payload, in the `wic:` block, or at the top level — and in both spellings, since §6.1 makes them equivalent. `Code.MISPLACED_EDGE_DEF`.
- The parser is deliberately stricter than the loader here: `anchor_constructor` is registered unconditionally, so `wic_loader` accepts `top: !& x`. Stricter is allowed; more permissive is not.
- The validator already agreed, by an older route: `_cwl_schema_inputs_props` composes each tool input from `str_nonempty | alias | ii` and has never admitted the anchor, and `_cwl_schema_out_tag` is the only place that does (`d3b08ee`). No schema change was needed.
- `_construct` derives from `Forms.DESUGARED`, so the generated schema needed no edit.
- Two tests moved rather than went away. `test_surface_forms_are_equivalent` quantified over input position, so its anchor row is now a sibling test on `out:`. `test_unknown_tags_report_wic009[over-desugared]` used `{wic_anchor: x}` as the payload inside `!foo`, which the new rule confounds, so it uses `wic_alias`; its claim is unchanged.

Reference §4.1 (five forms → four) plus a new §4.1.1 with the reasoning, and design §5.5 gains a position column — in `bbc7ca2`.

The Spec 2 chain sits on top of this.
