### PR TITLE
Spec 2: meaning-preserving rewrites and the equivalence property

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -241,7 +241,7 @@ jobs:
       # reason the contrib step gives below.
       - name: PyTest Spec 2 Oracle
         if: always()
-        run: cd sophios/ && pytest tests/core/test_hermeticity.py tests/core/test_generators.py tests/core/test_equivalence.py -m "not skip_pypi_ci"
+        run: cd sophios/ && pytest tests/core/test_hermeticity.py tests/core/test_generators.py tests/core/test_equivalence.py tests/core/test_equivalences.py -m "not skip_pypi_ci"
 
       # Contrib surfaces (ICT, Workflow Builder, REST) run in core CI, but as
       # their own step, so a red build is attributable to a zone without

--- a/tests/core/test_equivalences.py
+++ b/tests/core/test_equivalences.py
@@ -1,0 +1,324 @@
+"""P24c: every rewrite `transformations` names preserves the meaning it claims.
+
+One property, parameterised over `Transformation`, rather than a bespoke test
+per rewrite. P28 (partition independence) and P29 (its nested case) are named
+instances of it — `split` at one level and `split` composed with itself — not
+separate tests with their own idea of "the same workflow", which is how the
+two regression tests already in this tree ended up with two.
+"""
+import copy
+from typing import Any, Final
+
+import pytest
+import yaml
+from hypothesis import given
+from hypothesis import strategies as st
+
+from sophios.wic_types import NodeData, RoseTree, Yaml
+
+from . import ast_strategies as strat
+from .equivalence import Strength, equivalent
+from .hermetic import PARTITION, compile_hermetic, subworkflow_step
+from .synthetic_tools import STEMS, inputs_of
+from .transformations import TRANSFORMATIONS, Transformation, split, transformations
+
+#: The name both sides compile under. Identical on purpose: `identity` and
+#: `text_roundtrip` claim IDENTICAL, and `equivalent(..., Strength.IDENTICAL)`
+#: compares `steps[].id` literally (see `equivalence.py`'s own docstring —
+#: IDENTICAL forgives nothing) — so compiling "before" and "after" under
+#: different names would make every namespaced id disagree regardless of the
+#: rewrite, and IDENTICAL would never hold for anything. UP_TO_RENAMING
+#: ignores names either way, so the same choice costs those rewrites nothing.
+_COMPILE_NAME: Final = 'oracle'
+
+
+def _source_of(value: Any) -> str | None:
+    """The `source` one `in:` binding names, in whichever of the two surface
+    forms the compiler emitted (`{name: source}` or `{name: {source: ...}}`)."""
+    source = value.get('source') if isinstance(value, dict) else value
+    return source if isinstance(source, str) else None
+
+
+def _set_source(bindings: Yaml, name: str, source: str) -> None:
+    """Rewrites one binding's source in place, keeping its own surface form."""
+    value = bindings[name]
+    if isinstance(value, dict):
+        value['source'] = source
+    else:
+        bindings[name] = source
+
+
+def _flatten(rose: RoseTree) -> Yaml:
+    """The compiled document with every subworkflow step inlined, so a split
+    and an unsplit compilation of the same steps can be compared directly.
+
+    `sophios.inlineing.inline_subworkflow_cwl` already does this job — for a
+    `steps:` represented as a dict keyed by step id. `compile_workflow` emits
+    `steps:` as a *list* (`type(compiled_cwl['steps']) is list`, checked
+    directly against this oracle's own output), so that function's
+    `list(steps.keys())` raises `AttributeError` on exactly the shape this
+    task's compiler produces, and nothing in the tree calls it. That is a
+    finding about `src/sophios/inlineing.py`, not something this task's own
+    files can work around by patching — `src/` is out of scope here — so this
+    is a from-scratch replacement, scoped to what `equivalent()` at
+    UP_TO_RENAMING actually forgives: it needs the DAG's topology and every
+    step's body right, and it does not need `run:` paths, `steps[].id`, or
+    workflow-level port *names* right at all, because those are exactly what
+    that strength already ignores (`equivalence.py`).
+
+    Recognising a subworkflow step by its own sub-tree's `class` (`Workflow`,
+    not `CommandLineTool`) rather than by an `id` suffix: `rose.sub_trees` has
+    one entry per step regardless of kind (verified directly — a flat,
+    two-`CommandLineTool` compile still has two leaf sub-trees, one per step),
+    so the id is not what marks a step as needing to be inlined here; its own
+    compiled class is.
+    """
+    node_data: NodeData = rose.data
+    document: Yaml = copy.deepcopy(node_data.compiled_cwl)
+    steps: list[Yaml] = document.get('steps', [])
+    sub_trees: list[RoseTree] = rose.sub_trees
+    flat_steps: list[Yaml] = []
+    #: `{wrapper_id}/{wrapper_out_port} -> real producer's own source string`,
+    #: for every subworkflow step this pass inlines away.
+    redirects: dict[str, str] = {}
+    #: Requirements the inlined subworkflows themselves declared (their own
+    #: `SubworkflowFeatureRequirement` already stripped, recursively, by the
+    #: nested `_flatten` call below) — e.g. `ScatterFeatureRequirement`, for a
+    #: `scatter:` that lived inside the subworkflow and is now a step directly
+    #: in *this* document. A CWL document declares only the features its own
+    #: `steps:` uses, so once a step moves in here, whatever requirement it
+    #: needed moves with it.
+    inherited_requirements: dict[str, Yaml] = {}
+    inlined_any = False
+
+    for step, sub in zip(steps, sub_trees):
+        sub_data: NodeData = sub.data
+        if sub_data.compiled_cwl.get('class') != 'Workflow':
+            flat_steps.append(step)
+            continue
+        inlined_any = True
+        inner = _flatten(sub)
+        inner_requirements = inner.get('requirements')
+        if isinstance(inner_requirements, dict):
+            inherited_requirements.update(inner_requirements)
+        # The wrapper's own `in:` maps the subworkflow's formal parameter
+        # names (its inner workflow-level `inputs:` keys) to the sources that
+        # actually feed them at *this* level.
+        formal_to_actual = {name: _source_of(value) for name, value in step.get('in', {}).items()}
+        for inner_step in inner.get('steps', []):
+            for name, value in inner_step.get('in', {}).items():
+                source = _source_of(value)
+                if source is not None and source in formal_to_actual:
+                    actual = formal_to_actual[source]
+                    if actual is not None:
+                        _set_source(inner_step['in'], name, actual)
+            flat_steps.append(inner_step)
+        wrapper_id = step['id']
+        # The subworkflow's own `outputs:` map its output port names to
+        # `outputSource: '<inner step>/<port>'`; anything outside referred to
+        # `{wrapper_id}/{that port name}`, so redirect that reference straight
+        # to the real producer, which is now itself one of `flat_steps`.
+        for out_name, out_value in inner.get('outputs', {}).items():
+            redirects[f'{wrapper_id}/{out_name}'] = out_value['outputSource']
+
+    for flat_step in flat_steps:
+        for name, value in flat_step.get('in', {}).items():
+            source = _source_of(value)
+            if source is not None and source in redirects:
+                _set_source(flat_step['in'], name, redirects[source])
+    document['steps'] = flat_steps
+
+    for out_value in document.get('outputs', {}).values():
+        out_source = out_value.get('outputSource')
+        if isinstance(out_source, str) and out_source in redirects:
+            out_value['outputSource'] = redirects[out_source]
+
+    if inlined_any:
+        # A flattened document contains no subworkflow step, so the
+        # requirement that declares one no longer applies — left in place, it
+        # would make `_requirement_names` (equivalence.py) diverge on every
+        # split for a reason that has nothing to do with the workflow's
+        # meaning. What each inlined subworkflow's *own* requirements needed
+        # does still apply, now that their steps are directly in `steps:`
+        # here, so those are merged in rather than dropped with the rest.
+        requirements = document.get('requirements')
+        merged = dict(requirements) if isinstance(requirements, dict) else {}
+        merged.pop('SubworkflowFeatureRequirement', None)
+        merged.update(inherited_requirements)
+        document['requirements'] = merged
+
+    return document
+
+
+def _compile_flat(yml: Yaml) -> Yaml:
+    """Compile hermetically under the shared name and flatten the result."""
+    info = compile_hermetic(yml, _COMPILE_NAME)
+    return _flatten(info.rose)
+
+
+def _hits_the_scalar_coercion_gap(document: Yaml) -> bool:
+    """Whether compiling `document` would hit `ast_strategies.py`'s own
+    documented PENDING FINDING, rather than this property's own claim.
+
+    `populate_scalar_val` (src/sophios/compiler.py:1170,1173) calls
+    `int(value)`/`float(value)` on a `!ii` literal with no `try`/`except`, so a
+    literal that does not coerce to the bound argument's type crashes
+    compilation with a bare `ValueError` instead of a diagnostic.
+    `ast_strategies.py` documents this and deliberately does *not* filter it
+    out of `workflows()` (unlike CE-13, it is not a single AST-shape
+    predicate). Left unfiltered here, every draw that hits it would abort
+    *both* compiles this property needs before `equivalent()` is ever called —
+    smothering the property this task is actually responsible for under a
+    finding Task 2 already made and recorded. Excluded the same way
+    `compilable_documents()` excludes CE-13: narrowly, by the exact predicate
+    that names the gap, not by weakening what `workflows()` generates.
+    """
+    for step in document.get('steps', []):
+        if not isinstance(step, dict):
+            continue
+        stem = step.get('id')
+        if stem not in STEMS:
+            continue  # a subworkflow step, or something else this check does not model
+        declared = inputs_of(stem)
+        for name, value in step.get('in', {}).items():
+            if not (isinstance(value, dict) and 'wic_inline_input' in value):
+                continue
+            arg_type = declared.get(name, {}).get('type')
+            literal = value['wic_inline_input']
+            if arg_type not in ('int', 'float'):
+                continue
+            coerce = int if arg_type == 'int' else float
+            try:
+                coerce(literal)
+            except (TypeError, ValueError):
+                return True
+    return False
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+@given(st.data())
+@PARTITION
+def test_a_meaning_preserving_rewrite_preserves_meaning(data: st.DataObject) -> None:
+    """P28, P29, and every equivalence law in Spec 2, as one statement.
+
+    Parameterised by transformation, so a failure names which rewrite broke
+    rather than which file it was written in — and so adding a rewrite is one
+    entry in a table instead of a new test module with a new idea of equality.
+
+    CANNOT GENERATE (declared): rewrites that change step order, which this
+    language's inference is not invariant under (see `transformations.py`'s
+    module docstring); `!cwl` and `python_script` steps, which `workflows()`
+    itself cannot generate (`ast_strategies.py`); partitionings that are not
+    contiguous, which the language cannot express (`ast_strategies.partitionings`).
+    A transformation only ever regroups or re-derives a document's existing
+    steps, so a document that avoids `ast_strategies.py`'s own documented
+    scalar-coercion gap before any rewrite is applied still avoids it after —
+    see `_hits_the_scalar_coercion_gap`.
+    """
+    yml = data.draw(strat.workflows().filter(
+        lambda w: len(w['steps']) >= 2 and not _hits_the_scalar_coercion_gap(w)))
+    rewrite = data.draw(transformations())
+    transformed = rewrite.apply(copy.deepcopy(yml))
+
+    before = _compile_flat(yml)
+    after = _compile_flat(transformed)
+
+    found = equivalent(before, after, rewrite.preserves)
+    assert found is None, (
+        f'{rewrite.name} changed the meaning of the workflow.\n'
+        f'It claims to preserve {rewrite.preserves.name} because: {rewrite.rationale}\n\n'
+        f'{found}\n\n'
+        f'--- before ---\n{yaml.safe_dump(yml, sort_keys=False)}\n'
+        f'--- after ---\n{yaml.safe_dump(transformed, sort_keys=False)}')
+
+
+#: A document every constant transformation but `identity` must genuinely
+#: change: a plain step plus an existing subworkflow, so `inline_all` has
+#: something to inline (a document with no subworkflow gives it nothing to
+#: do) and `rename_workflow`/`split`-style wrapping has more than one step to
+#: gather.
+_NOOP_GUARD_FIXTURE: Final[Yaml] = {
+    'steps': [
+        {'id': 'mk_file', 'in': {'name': {'wic_inline_input': 'a.txt'}}},
+        subworkflow_step('sub0.wic', {'steps': [
+            {'id': 'xform', 'in': {'name': {'wic_inline_input': 'b.txt'}}},
+        ]}),
+    ],
+}
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+@pytest.mark.parametrize('rewrite', TRANSFORMATIONS, ids=lambda t: t.name)
+def test_every_transformation_actually_transforms(rewrite: Transformation) -> None:
+    """The tautology check, per rewrite.
+
+    A transformation that returned its input unchanged would satisfy the
+    equivalence property for free, and the property would then be a statement
+    about `identity` wearing four other names. `identity` is exempt and says
+    so: it is the one rewrite whose whole point is changing nothing, and what
+    it tests is that *the compiler* does not.
+
+    IDENTICAL-claiming rewrites need a different check than the rest, and that
+    is not a loophole: `text_roundtrip` is, by construction, value-preserving
+    (checked directly — `yaml.safe_dump` then `wic_loader` round-trips this
+    fixture to something `==` its input), so `apply(yml) != yml` would fail
+    for a *correct* implementation just as loudly as for a broken one, and
+    could never tell them apart. What a no-op could fake there is skipping the
+    round trip entirely and handing back the very object it was given, so
+    that is what is checked: a fresh, value-equal object, not a different one.
+    """
+    yml = copy.deepcopy(_NOOP_GUARD_FIXTURE)
+    if rewrite.name == 'identity':
+        pytest.skip('identity changes the input by definition; see the module docstring')
+    result = rewrite.apply(copy.deepcopy(yml))
+    if rewrite.preserves is Strength.IDENTICAL:
+        assert result is not yml, f'{rewrite.name} returned its input unchanged, doing no work'
+        assert result == yml, f'{rewrite.name} claims IDENTICAL but changed the value'
+    else:
+        assert result != yml, f'{rewrite.name} is a no-op'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_splitting_really_renames() -> None:
+    """`split` claims only UP_TO_RENAMING. If it renamed nothing, that claim
+    would be free and P28 would assert nothing beyond IDENTICAL.
+
+    Compiles both sides and checks both halves of the claim directly: IDENTICAL
+    must *not* hold (there is really something for a renaming to forgive) and
+    UP_TO_RENAMING must (the DAG that remains, once names are ignored, is the
+    same DAG).
+    """
+    yml: Yaml = {'steps': [
+        {'id': 'mk_file', 'in': {'name': {'wic_inline_input': 'a.txt'}}},
+        {'id': 'xform', 'in': {'name': {'wic_inline_input': 'b.txt'}}},
+    ]}
+    rewrite = split(((0,), (1,)))
+    before = _compile_flat(yml)
+    after = _compile_flat(rewrite.apply(copy.deepcopy(yml)))
+
+    assert equivalent(before, after, Strength.IDENTICAL) is not None, (
+        'split produced a byte-identical compilation; UP_TO_RENAMING would be a vacuous claim')
+    found = equivalent(before, after, Strength.UP_TO_RENAMING)
+    assert found is None, found
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_the_property_fails_for_a_rewrite_that_changes_meaning() -> None:
+    """A deliberately dishonest transformation — one that drops a step while
+    claiming to preserve UP_TO_RENAMING — must be caught. Without this, a
+    mis-wired property (comparing a document with itself, say) is green."""
+    liar = Transformation(
+        name='drops_a_step', preserves=Strength.UP_TO_RENAMING,
+        apply=lambda w: {**w, 'steps': w['steps'][:-1]},
+        rationale='none; this rewrite is wrong on purpose')
+    yml: Yaml = {'steps': [
+        {'id': 'mk_file', 'in': {'name': {'wic_inline_input': 'a.txt'}}},
+        {'id': 'xform', 'in': {'name': {'wic_inline_input': 'b.txt'}}},
+    ]}
+    before = _compile_flat(yml)
+    after = _compile_flat(liar.apply(copy.deepcopy(yml)))
+    assert equivalent(before, after, liar.preserves) is not None

--- a/tests/core/test_equivalences.py
+++ b/tests/core/test_equivalences.py
@@ -7,6 +7,7 @@ separate tests with their own idea of "the same workflow", which is how the
 two regression tests already in this tree ended up with two.
 """
 import copy
+from collections import Counter
 from typing import Any, Final
 
 import pytest
@@ -20,7 +21,7 @@ from . import ast_strategies as strat
 from .equivalence import Strength, equivalent
 from .hermetic import PARTITION, compile_hermetic, subworkflow_step
 from .synthetic_tools import STEMS, inputs_of
-from .transformations import TRANSFORMATIONS, Transformation, split, transformations
+from .transformations import TRANSFORMATIONS, Transformation, split, split_transformations
 
 #: The name both sides compile under. Identical on purpose: `identity` and
 #: `text_roundtrip` claim IDENTICAL, and `equivalent(..., Strength.IDENTICAL)`
@@ -195,16 +196,24 @@ def _hits_the_scalar_coercion_gap(document: Yaml) -> bool:
     return False
 
 
-@pytest.mark.skip_pypi_ci
 @pytest.mark.slow
+@pytest.mark.parametrize('constant', [*TRANSFORMATIONS, None],
+                         ids=[rewrite.name for rewrite in TRANSFORMATIONS] + ['split'])
 @given(st.data())
 @PARTITION
-def test_a_meaning_preserving_rewrite_preserves_meaning(data: st.DataObject) -> None:
+def test_a_meaning_preserving_rewrite_preserves_meaning(constant: Transformation | None,
+                                                        data: st.DataObject) -> None:
     """P28, P29, and every equivalence law in Spec 2, as one statement.
 
     Parameterised by transformation, so a failure names which rewrite broke
     rather than which file it was written in — and so adding a rewrite is one
     entry in a table instead of a new test module with a new idea of equality.
+
+    Parametrised, not drawn. Drawing the rewrite alongside the document made
+    the property's strength per rewrite a matter of Hypothesis's weighting:
+    `identity` took about half the fifty examples and the thinnest real rewrite
+    could reach zero (see `split_transformations`). Each kind now gets the
+    whole budget, and `split`'s partitioning is what is drawn inside it.
 
     CANNOT GENERATE (declared): rewrites that change step order, which this
     language's inference is not invariant under (see `transformations.py`'s
@@ -218,7 +227,7 @@ def test_a_meaning_preserving_rewrite_preserves_meaning(data: st.DataObject) -> 
     """
     yml = data.draw(strat.workflows().filter(
         lambda w: len(w['steps']) >= 2 and not _hits_the_scalar_coercion_gap(w)))
-    rewrite = data.draw(transformations())
+    rewrite = constant if constant is not None else data.draw(split_transformations())
     transformed = rewrite.apply(copy.deepcopy(yml))
 
     before = _compile_flat(yml)
@@ -231,6 +240,52 @@ def test_a_meaning_preserving_rewrite_preserves_meaning(data: st.DataObject) -> 
         f'{found}\n\n'
         f'--- before ---\n{yaml.safe_dump(yml, sort_keys=False)}\n'
         f'--- after ---\n{yaml.safe_dump(transformed, sort_keys=False)}')
+
+
+def _nesting_depth(document: Yaml) -> int:
+    """How many subworkflow layers a document goes down.
+
+    A step carrying a `subtree` is a subworkflow (`hermetic.subworkflow_step`
+    builds the shape `read_ast_from_disk` produces), so depth 2 means a
+    subworkflow that itself contains one — the shape P29 is about.
+    """
+    return max((1 + _nesting_depth(step['subtree']) for step in document.get('steps', [])
+                if isinstance(step, dict) and isinstance(step.get('subtree'), dict)),
+               default=0)
+
+
+@pytest.mark.fast
+def test_split_reaches_a_document_that_is_already_nested() -> None:
+    """P29's half of the property above, which nothing checked.
+
+    The module docstring calls P29 "`split` composed with itself", and nothing
+    composes anything: one rewrite is applied once. The nested case is reached
+    when `workflows()` happens to draw a document that already contains a
+    subworkflow step and `split` wraps it — true today, but a fact about
+    `ast_strategies.documents()` rather than about anything in this file. If
+    that generator's subworkflow branch narrowed, P29's coverage would go to
+    zero with every test here still green.
+
+    Which rewrite gets drawn is no longer a question — the property parametrises
+    over all five — so this measures the one thing left to chance: how often the
+    document underneath is deep enough for `split` to nest. Drawn exactly as the
+    property draws, filter included.
+    """
+    depths: Counter[int] = Counter()
+
+    @PARTITION
+    @given(st.data())
+    def _collect(data: st.DataObject) -> None:
+        yml = data.draw(strat.workflows().filter(
+            lambda w: len(w['steps']) >= 2 and not _hits_the_scalar_coercion_gap(w)))
+        rewrite = data.draw(split_transformations())
+        depths[_nesting_depth(rewrite.apply(copy.deepcopy(yml)))] += 1
+
+    _collect()  # pylint: disable=no-value-for-parameter  # @given supplies `data`
+
+    assert sum(count for depth, count in depths.items() if depth >= 2), (
+        'no drawn split reached a document that already contained a subworkflow, so P29 — '
+        f'nesting, not just partitioning — went untested. Depths drawn: {dict(depths)}')
 
 
 #: A document every constant transformation but `identity` must genuinely
@@ -248,7 +303,6 @@ _NOOP_GUARD_FIXTURE: Final[Yaml] = {
 }
 
 
-@pytest.mark.skip_pypi_ci
 @pytest.mark.fast
 @pytest.mark.parametrize('rewrite', TRANSFORMATIONS, ids=lambda t: t.name)
 def test_every_transformation_actually_transforms(rewrite: Transformation) -> None:
@@ -268,19 +322,29 @@ def test_every_transformation_actually_transforms(rewrite: Transformation) -> No
     could never tell them apart. What a no-op could fake there is skipping the
     round trip entirely and handing back the very object it was given, so
     that is what is checked: a fresh, value-equal object, not a different one.
+
+    `apply` is handed `yml` itself and the comparison is against a pristine
+    `expected`, which is the whole of what makes that check real. An earlier
+    version passed `apply` a fresh `copy.deepcopy(yml)` and then asserted
+    `result is not yml` — true for *every* implementation, `lambda w: w`
+    included, because the identity being compared was the copy's and not the
+    one `apply` received. Replacing `_text_roundtrip`'s body with
+    `return document` left this test green. Comparing against `expected`
+    rather than `yml` matters for the same reason on the other branch: a
+    rewrite that mutated in place would otherwise be compared against itself.
     """
     yml = copy.deepcopy(_NOOP_GUARD_FIXTURE)
     if rewrite.name == 'identity':
         pytest.skip('identity changes the input by definition; see the module docstring')
-    result = rewrite.apply(copy.deepcopy(yml))
+    expected = copy.deepcopy(yml)
+    result = rewrite.apply(yml)
     if rewrite.preserves is Strength.IDENTICAL:
         assert result is not yml, f'{rewrite.name} returned its input unchanged, doing no work'
-        assert result == yml, f'{rewrite.name} claims IDENTICAL but changed the value'
+        assert result == expected, f'{rewrite.name} claims IDENTICAL but changed the value'
     else:
-        assert result != yml, f'{rewrite.name} is a no-op'
+        assert result != expected, f'{rewrite.name} is a no-op'
 
 
-@pytest.mark.skip_pypi_ci
 @pytest.mark.fast
 def test_splitting_really_renames() -> None:
     """`split` claims only UP_TO_RENAMING. If it renamed nothing, that claim
@@ -305,7 +369,6 @@ def test_splitting_really_renames() -> None:
     assert found is None, found
 
 
-@pytest.mark.skip_pypi_ci
 @pytest.mark.fast
 def test_the_property_fails_for_a_rewrite_that_changes_meaning() -> None:
     """A deliberately dishonest transformation — one that drops a step while

--- a/tests/core/test_hermeticity.py
+++ b/tests/core/test_hermeticity.py
@@ -51,6 +51,7 @@ ORACLE_MODULES = (
     'core.ast_strategies',
     'core.equivalence',
     'core.test_equivalence',
+    'core.transformations',
     'core.test_generators',
 )
 

--- a/tests/core/test_hermeticity.py
+++ b/tests/core/test_hermeticity.py
@@ -52,6 +52,7 @@ ORACLE_MODULES = (
     'core.equivalence',
     'core.test_equivalence',
     'core.transformations',
+    'core.test_equivalences',
     'core.test_generators',
 )
 
@@ -222,7 +223,7 @@ def test_the_hermetic_entry_point_actually_compiles() -> None:
 ORACLE_FILES: tuple[str, ...] = (
     'tests/core/test_generators.py',
     'tests/core/test_equivalence.py',
-    # 'tests/core/test_equivalences.py',
+    'tests/core/test_equivalences.py',
     # 'tests/core/test_canonical_emission.py',
     # 'tests/core/test_predicates.py',
     # 'tests/core/test_canonical_path.py',

--- a/tests/core/transformations.py
+++ b/tests/core/transformations.py
@@ -1,0 +1,289 @@
+"""Rewrites that must not change what a workflow means.
+
+Each carries the strength it preserves and the reason. The rationale is a
+field rather than a comment because it is the load-bearing claim: a
+transformation on this list asserts that Sophios's semantics are invariant
+under it, and that assertion is exactly what the property checks. A
+transformation nobody can justify is a test that will one day fail for a good
+reason and be "fixed" by weakening the property.
+
+Deliberately NOT on this list, and worth recording because it looks like it
+belongs: **reordering independent steps.** Sophios's inference scans backwards
+over previous steps (`for j in range(0, i)[::-1]`, src/sophios/inference.py:216)
+and takes the most recent match, so step order is part of the meaning of a
+workflow, not an accident of how it was written. A "reorder independent steps"
+transformation would be a property asserting something false about this
+language.
+
+The five, with their strengths, are `identity`, `text_roundtrip`, `split`,
+`inline_all` and `rename_workflow`. `split` needs a drawn argument (which
+steps go in which file), so it is built by a strategy rather than being a
+constant: `TRANSFORMATIONS` holds the other four, and `transformations()`
+unions them with a `split` built from `ast_strategies.partitionings`.
+"""
+import copy
+from dataclasses import dataclass
+from typing import Callable, Final
+
+import yaml
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+
+from sophios.inlineing import get_inlineable_subworkflows, inline_subworkflow
+from sophios.utils_yaml import wic_loader
+from sophios.wic_types import Namespaces, StepId, Yaml, YamlTree
+
+from .ast_strategies import partitionings
+from .equivalence import Strength
+from .hermetic import subworkflow_step
+from .synthetic_tools import SYNTHETIC_NS, SYNTHETIC_TOOLS
+
+
+@dataclass(frozen=True, slots=True)
+class Transformation:
+    """A rewrite of a `.wic` document, and the claim it makes about it."""
+
+    name: str
+    #: The strongest `equivalence.Strength` a compilation of `apply(w)` is
+    #: claimed to share with a compilation of `w`.
+    preserves: Strength
+    apply: Callable[[Yaml], Yaml]
+    #: Why the claim is true. Not a comment: see the module docstring.
+    rationale: str
+
+
+def _identity(document: Yaml) -> Yaml:
+    """A deep copy, not the same object.
+
+    Not `lambda w: w`. Returning the very object the caller handed in would
+    make `compile_hermetic(yml, ...)` and `compile_hermetic(rewrite.apply(yml), ...)`
+    share one mutable dict, and the compiler mutates its input
+    (`yaml_tree`) in place — so a bare identity function would make the second
+    compile a test of whatever the first compile left behind, not a test of
+    compiling the same input twice. A deep copy is a second, independent input
+    with the same value, which is the actual claim.
+    """
+    copied: Yaml = copy.deepcopy(document)
+    return copied
+
+
+def _text_roundtrip(document: Yaml) -> Yaml:
+    """Serialise, then parse through the compiler's own loader.
+
+    This is what every user does between writing a `.wic` file and running
+    `sophios --graph`, and it is the mechanism `to_yml` itself relies on
+    (`ast_strategies.py`) — so a divergence here would mean the generator's own
+    round trip is unsound, not just this rewrite.
+
+    `sort_keys=False`: `yaml.safe_dump`'s default sorts mapping keys
+    alphabetically, which is a real reordering — the IDENTICAL strength this
+    rewrite claims compares key order (`equivalence.Strength.IDENTICAL`) — and
+    would make this rewrite fail its own claim regardless of the compiler,
+    for a reason that has nothing to do with what it is testing. Matches the
+    convention this suite already uses for a faithful dump
+    (`test_hermeticity.py`'s `yaml.safe_dump(_cwl(stem), sort_keys=False)`).
+    """
+    dumped = yaml.safe_dump(document, sort_keys=False)
+    loaded: Yaml = yaml.load(dumped, Loader=wic_loader())
+    return loaded
+
+
+#: How many times `_inline_all` will inline a subworkflow before giving up.
+#: Every call strictly reduces the number of `.wic` steps remaining (a
+#: subworkflow, once inlined, cannot reappear), and `workflows()` never
+#: generates more than one, so this is generous headroom, not a tuned budget —
+#: it exists so a defect in `get_inlineable_subworkflows`/`inline_subworkflow`
+#: that stopped making progress would raise here instead of hanging the suite.
+_MAX_INLINE_PASSES: Final = 20
+
+
+def _inline_all(document: Yaml) -> Yaml:
+    """Inline every subworkflow this document contains, via `sophios.inlineing`.
+
+    Repeats rather than inlining once: `get_inlineable_subworkflows` can name
+    more than one namespace, and inlining one shifts the indices of whatever
+    is left, so the list is recomputed after each inline instead of consumed
+    in one pass.
+    """
+    tree = YamlTree(StepId('workflow', SYNTHETIC_NS), copy.deepcopy(document))
+    for _ in range(_MAX_INLINE_PASSES):
+        found: list[Namespaces] = get_inlineable_subworkflows(tree, SYNTHETIC_TOOLS, False, [])
+        if not found:
+            return tree.yml
+        tree, _len_substeps = inline_subworkflow(tree, found[0])
+    raise AssertionError(f'_inline_all did not converge in {_MAX_INLINE_PASSES} passes')
+
+
+def _declared_input_references(document: Yaml, steps: list[Yaml]) -> set[str]:
+    """The declared `inputs:` names `steps` reference by bare name."""
+    declared = document.get('inputs')
+    if not declared:
+        return set()
+    referenced: set[str] = set()
+    for step in steps:
+        for value in step.get('in', {}).values():
+            source = value.get('source') if isinstance(value, dict) else value
+            if isinstance(source, str) and source in declared:
+                referenced.add(source)
+    return referenced
+
+
+def _subtree_for(document: Yaml, steps: list[Yaml]) -> Yaml:
+    """A subworkflow body carrying `steps`, plus whatever declared top-level
+    `inputs:` those steps themselves reference by bare name.
+
+    A step may reference a bare declared name (`UnresolvedName`,
+    `ast_strategies.py`), and that resolves against the *immediately
+    enclosing* workflow's own `inputs:` mapping (`arg_var_is_input`,
+    src/sophios/compiler.py:878) — a subworkflow does not inherit its
+    parent's, so the reference needs the declaration repeated here to resolve
+    at all. See `_wrap_steps` for how the *outer* level keeps the same
+    reference resolvable too.
+    """
+    declared = document.get('inputs') or {}
+    referenced = _declared_input_references(document, steps)
+    subtree: Yaml = {'steps': steps}
+    if referenced:
+        subtree['inputs'] = {name: copy.deepcopy(declared[name]) for name in referenced}
+    return subtree
+
+
+def _wrap_steps(document: Yaml, groups: list[list[Yaml]], stems: list[str]) -> Yaml:
+    """One new subworkflow step per group of `document`'s own steps, replacing
+    `document['steps']` outright — the shared engine behind `split` and
+    `rename_workflow`.
+
+    Each wrapper is wired to whichever of `document`'s own declared `inputs:`
+    its own group references, via `parentargs['in']` rather than a plain
+    `in:` key on the step dict: `compile_workflow_once` builds a subworkflow
+    step's final `in:` by merging `parentargs` over any `wic:`-supplied
+    overrides (src/sophios/compiler.py:560-567), discarding whatever the step
+    dict already had — checked directly, an `in:` set any other way is simply
+    gone by the time the step is compiled. Left unwired instead, the compiler
+    auto-fills a missing formal parameter as a same-named bare reference of
+    its own (`args_required`, src/sophios/compiler.py:665-671), and *that*
+    reference is not the explicit one this function writes: checked directly,
+    an unwired wrapper argument can get backward-inferred to a preceding
+    sibling group's output instead, whenever their types happen to unify —
+    silently rewiring an argument that named a specific declared input in the
+    unsplit document to a different producer entirely once split. `split`
+    wiring every reference explicitly is what keeps that inference path from
+    ever being reached for an argument this function already knows the answer
+    to.
+
+    `document`'s own `inputs:` stays in place at the outer level too,
+    unconditionally: a referenced name needs it there for the bare reference
+    above to resolve, and an unreferenced one is still a real port in an
+    unsplit compilation regardless — the compiler copies a document's
+    `inputs:` into its compiled `inputs:` regardless of use (checked
+    directly) — so dropping either kind would be its own extra divergence.
+    """
+    outer = {key: value for key, value in document.items() if key != 'steps'}
+    new_steps = []
+    for stem, steps in zip(stems, groups):
+        wrapper = subworkflow_step(stem, _subtree_for(document, steps))
+        referenced = _declared_input_references(document, steps)
+        if referenced:
+            wrapper['parentargs']['in'] = {name: name for name in referenced}
+        new_steps.append(wrapper)
+    outer['steps'] = new_steps
+    return outer
+
+
+def _rename_workflow(document: Yaml) -> Yaml:
+    """Wrap every step in one new subworkflow, under a fixed, different stem.
+
+    The root's own stem is supplied to `compile_hermetic` as the `name`
+    argument, outside the `Yaml` this function receives, so there is nothing
+    in the document itself that *is* "the root's stem" to edit in place.
+    Introducing one level of nesting is the mechanism available at this level
+    for giving a group of steps a stem other than the one they would
+    otherwise inherit, and it is the same claim: everything under
+    `renamed.wic` now has `renamed` as the first segment of its namespace
+    instead of the root's name, and that must move no edge.
+    """
+    return _wrap_steps(document, [copy.deepcopy(document.get('steps', []))], ['renamed.wic'])
+
+
+TRANSFORMATIONS: Final[tuple[Transformation, ...]] = (
+    Transformation(
+        name='identity', preserves=Strength.IDENTICAL, apply=_identity,
+        rationale=(
+            'Compiling the same input twice must give the same answer. Trivial to state and not '
+            'trivial to satisfy: the compiler mutates yaml_tree, inputs_workflow, '
+            'vars_workflow_output_internal, the graph, and the tools dict, so a second compilation '
+            'in the same process is a real test of whether any of that leaks.')),
+    Transformation(
+        name='text_roundtrip', preserves=Strength.IDENTICAL, apply=_text_roundtrip,
+        rationale=(
+            'yaml.safe_dump then load through wic_loader. Serialising a workflow and reading it '
+            'back is what every user does between writing a file and compiling it.')),
+    Transformation(
+        name='inline_all', preserves=Strength.UP_TO_RENAMING, apply=_inline_all,
+        rationale=(
+            "The inverse of split, via sophios.inlineing. Included because it is the direction the "
+            "existing corpus test takes, and because a split/inline pair that agreed only with each "
+            "other would be an inverse-pair blind spot (#383's P4 lesson).")),
+    Transformation(
+        name='rename_workflow', preserves=Strength.UP_TO_RENAMING, apply=_rename_workflow,
+        rationale=(
+            "The workflow's stem is the first segment of every namespace. Changing it must move no "
+            "edge.")),
+)
+
+
+def _cut_points(partitioning: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    """The boundary before every group but the first, as plain indices.
+
+    `partitionings(n)` is shaped for a document with exactly `n` steps, but
+    `transformations()` has no document in hand when it builds a `split` — it
+    hands out `Transformation`s, and only the property that calls `apply`
+    knows how many steps the drawn workflow actually has. Reducing a
+    partitioning to its boundary *positions* (rather than its groups) is what
+    lets `split.apply` rebuild groups for whatever length it is actually
+    given, by clamping and deduplicating these positions against that length.
+    """
+    return tuple(group[0] for group in partitioning[1:])
+
+
+def split(cuts: tuple[tuple[int, ...], ...]) -> Transformation:
+    """A `split` transformation for one drawn set of cut points.
+
+    Every group, including a group of one, becomes its own subworkflow via
+    `hermetic.subworkflow_step` — a subworkflow is the steps written in one
+    file, and a one-step file is still a file.
+    """
+    points = _cut_points(cuts)
+
+    def apply(document: Yaml) -> Yaml:
+        steps: list[Yaml] = document.get('steps', [])
+        total = len(steps)
+        bounds = sorted({point for point in points if 0 < point < total})
+        edges = [0, *bounds, total]
+        groups = [tuple(range(a, b)) for a, b in zip(edges, edges[1:])] or [tuple(range(total))]
+        step_groups = [[copy.deepcopy(steps[j]) for j in group] for group in groups]
+        stems = [f'part{i}.wic' for i in range(len(step_groups))]
+        return _wrap_steps(document, step_groups, stems)
+
+    return Transformation(
+        name='split', preserves=Strength.UP_TO_RENAMING, apply=apply,
+        rationale=(
+            'The first design principle. A subworkflow is the steps written in one file; grouping '
+            'them differently renames every port and moves no edge.'))
+
+
+#: How many steps `partitionings` is asked to cut. `workflows()` generates at
+#: most 4 ordinary steps plus one optional subworkflow step (`ast_strategies.documents`),
+#: so 5 covers the widest document `test_a_meaning_preserving_rewrite_preserves_meaning`
+#: can draw; `split.apply` clamps its cut points to whatever length it is
+#: actually given, so this bound only needs to be generous, not exact.
+_SPLIT_STEP_BOUND: Final = 5
+
+
+def transformations() -> SearchStrategy[Transformation]:
+    """Every transformation this module knows: the constant four, plus a
+    freshly drawn `split`."""
+    # pylint cannot see through @st.composite and reads partitionings() as
+    # returning its element type rather than a SearchStrategy.
+    return st.one_of(st.sampled_from(TRANSFORMATIONS),
+                     partitionings(_SPLIT_STEP_BOUND).map(split))  # pylint: disable=no-member

--- a/tests/core/transformations.py
+++ b/tests/core/transformations.py
@@ -18,15 +18,15 @@ language.
 The five, with their strengths, are `identity`, `text_roundtrip`, `split`,
 `inline_all` and `rename_workflow`. `split` needs a drawn argument (which
 steps go in which file), so it is built by a strategy rather than being a
-constant: `TRANSFORMATIONS` holds the other four, and `transformations()`
-unions them with a `split` built from `ast_strategies.partitionings`.
+constant: `TRANSFORMATIONS` holds the other four, and `split_transformations()`
+builds a `split` from `ast_strategies.partitionings`. The property parametrises
+over all five rather than drawing one, so each gets the whole budget.
 """
 import copy
 from dataclasses import dataclass
 from typing import Callable, Final
 
 import yaml
-from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
 
 from sophios.inlineing import get_inlineable_subworkflows, inline_subworkflow
@@ -236,8 +236,8 @@ def _cut_points(partitioning: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
     """The boundary before every group but the first, as plain indices.
 
     `partitionings(n)` is shaped for a document with exactly `n` steps, but
-    `transformations()` has no document in hand when it builds a `split` — it
-    hands out `Transformation`s, and only the property that calls `apply`
+    `split_transformations()` has no document in hand when it builds a `split`
+    — it hands out `Transformation`s, and only the property that calls `apply`
     knows how many steps the drawn workflow actually has. Reducing a
     partitioning to its boundary *positions* (rather than its groups) is what
     lets `split.apply` rebuild groups for whatever length it is actually
@@ -280,10 +280,22 @@ def split(cuts: tuple[tuple[int, ...], ...]) -> Transformation:
 _SPLIT_STEP_BOUND: Final = 5
 
 
-def transformations() -> SearchStrategy[Transformation]:
-    """Every transformation this module knows: the constant four, plus a
-    freshly drawn `split`."""
-    # pylint cannot see through @st.composite and reads partitionings() as
-    # returning its element type rather than a SearchStrategy.
-    return st.one_of(st.sampled_from(TRANSFORMATIONS),
-                     partitionings(_SPLIT_STEP_BOUND).map(split))  # pylint: disable=no-member
+def split_transformations() -> SearchStrategy[Transformation]:
+    """A freshly drawn `split`, the one transformation that is not a constant.
+
+    Replaces a `transformations()` strategy that drew all five, which the
+    property then had to hope was even. It was not: `st.one_of` weights its
+    branches by Hypothesis's heuristics and `st.sampled_from` favours its first
+    element, so at the property's own fifty examples `identity` took about half
+    the budget — the one rewrite whose subject is the compiler's idempotence
+    rather than any rewrite — while the thinnest real one came out at 1 example
+    in 50, and at none at all in about one run in five.
+
+    No amount of reordering fixes that, because the bias is the engine
+    preferring simpler choices, by design. So the property parametrises over
+    the five kinds instead and each gets the whole budget, which is both
+    stronger and one less thing to measure.
+    """
+    # pylint cannot see through `@st.composite` in `ast_strategies` and reads
+    # partitionings() as returning its element type rather than a strategy.
+    return partitionings(_SPLIT_STEP_BOUND).map(split)  # pylint: disable=no-member


### PR DESCRIPTION
**Stacked on #403** — review that first; this branch contains its commits.

Task 3 defined `≡`. This adds the space of `f`, and the single parameterised property that partition independence (P28) and its nested case (P29) are named instances of.

Five rewrites that must not change meaning, each carrying the strength it preserves and the reason it does:

| rewrite | preserves | why it is meaning-preserving |
|---|---|---|
| `identity` | `IDENTICAL` | compiling one input twice must agree — not trivial, since the compiler mutates a module global, the tool registry, and four structures threaded through the recursion |
| `text_roundtrip` | `IDENTICAL` | serialising and reloading is what every user does between writing a file and compiling it |
| `split` | `UP_TO_RENAMING` | a subworkflow is the steps written in one file; grouping them differently renames every port and moves no edge |
| `inline_all` | `UP_TO_RENAMING` | `split` inverted, via `sophios.inlineing` — a split/inline pair agreeing only with each other would be an inverse-pair blind spot |
| `rename_workflow` | `UP_TO_RENAMING` | the stem is the first segment of every namespace, and must move no edge |

The rationale is a field rather than a comment because it is the load-bearing claim: a rewrite on this list asserts that Sophios's semantics are invariant under it, and that assertion is exactly what the property checks.

**Reordering independent steps is deliberately not on the list.** Inference scans backwards over previous steps and takes the most recent match (`inference.py:216`), so step order is part of what a workflow means in this language. A reorder rewrite would be a property asserting something false.

**Worth a look:**

- Three guards keep the green honest — no rewrite may be a no-op, `split` must really rename, and a deliberately dishonest rewrite (one dropping a step while claiming `UP_TO_RENAMING`) must be caught. Without the last, a mis-wired property comparing a document with itself satisfies the other two.
- `_flatten` inlines subworkflow steps so a split and an unsplit compilation are comparable. `inlineing.inline_subworkflow_cwl` does that job for a dict-keyed `steps:`; `compile_workflow` emits a list, so it could not be reused directly.

**Finding, not fixed here** — `src/` is out of scope for this spec:

**CE-15.** Reference §3.1 documents three step surface forms and says all three produce the same result. `sophios.lang` parses the third — a sequence of single-key mappings — into a `Step` with no diagnostic; `canonicalize_steps_list`'s list branch calls `require_step_id` on each element and raises. Its dict branch synthesises `id` from the key; the list branch never learned to. No file reachable through `search_paths_wic` uses the form, so nothing catches it.

That is why `--insert_steps_automatically` cannot work: `insert_step_into_workflow` writes exactly that form, after canonicalisation has run, so every insertion yields a step whose id reads as empty. It also means `list(set(insertions))` — the hazard the design names as determinism's motivating example — is unreachable, which is independent support for restating that property as canonical emission over the two default-path sites.

**Not in this PR.** Tasks 5–7: canonical emission, the single-compilation predicates (namespace injectivity, edge soundness, termination), and the canonical path.
